### PR TITLE
test/15 - add unit tests for Category mappers

### DIFF
--- a/service/src/test/java/greencity/mapping/CategoryDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CategoryDtoMapperTest.java
@@ -1,0 +1,35 @@
+package greencity.mapping;
+
+import greencity.dto.category.CategoryDto;
+import greencity.entity.Category;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CategoryDtoMapperTest {
+
+    private final CategoryDtoMapper mapper = new CategoryDtoMapper();
+
+    @Test
+    void convert_validCategoryDto_returnsValidEntity() {
+        Category expected = Category.builder()
+                .name("test")
+                .build();
+
+        CategoryDto categoryDto = CategoryDto.builder()
+                .name(expected.getName())
+                .build();
+
+        Category actual = mapper.convert(categoryDto);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void convert_emptyDto_fieldsNullOrDefault() {
+        Category expected = new Category();
+        Category actual = mapper.convert(new CategoryDto());
+
+        assertEquals(expected, actual);
+    }
+}

--- a/service/src/test/java/greencity/mapping/CategoryDtoResponseMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CategoryDtoResponseMapperTest.java
@@ -1,0 +1,30 @@
+package greencity.mapping;
+
+import greencity.dto.category.CategoryDtoResponse;
+import greencity.entity.Category;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CategoryDtoResponseMapperTest {
+    private final CategoryDtoResponseMapper categoryDtoResponseMapper = new CategoryDtoResponseMapper();
+
+    @Test
+    public void convert_validEntity_returnsCategoryDtoResponse() {
+        Category category = Category.builder()
+                .id(1L)
+                .name("test")
+                .build();
+
+        CategoryDtoResponse categoryDtoResponse = CategoryDtoResponse.builder()
+                .id(1L)
+                .name("test")
+                .build();
+
+        CategoryDtoResponse actual = categoryDtoResponseMapper.convert(category);
+        assertEquals(categoryDtoResponse, actual);
+    }
+}

--- a/service/src/test/java/greencity/mapping/CategoryDtoResponseMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CategoryDtoResponseMapperTest.java
@@ -3,11 +3,9 @@ package greencity.mapping;
 import greencity.dto.category.CategoryDtoResponse;
 import greencity.entity.Category;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class CategoryDtoResponseMapperTest {
     private final CategoryDtoResponseMapper categoryDtoResponseMapper = new CategoryDtoResponseMapper();
@@ -19,12 +17,35 @@ public class CategoryDtoResponseMapperTest {
                 .name("test")
                 .build();
 
-        CategoryDtoResponse categoryDtoResponse = CategoryDtoResponse.builder()
+        CategoryDtoResponse expected = CategoryDtoResponse.builder()
                 .id(1L)
                 .name("test")
                 .build();
 
         CategoryDtoResponse actual = categoryDtoResponseMapper.convert(category);
-        assertEquals(categoryDtoResponse, actual);
+
+        assertThat(actual).isNotNull();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void convert_dtoWithNullFields_returnsCategoryDtoResponse() {
+        Category category = Category.builder()
+                .id(null)
+                .name(null)
+                .build();
+
+        CategoryDtoResponse actual = categoryDtoResponseMapper.convert(category);
+        assertThat(actual).isNotNull();
+        assertThat(actual.getId()).isNull();
+        assertThat(actual.getName()).isNull();
+    }
+
+    @Test
+    public void convert_emptyDto_fieldsNullOrDefault() {
+        CategoryDtoResponse expected = new CategoryDtoResponse();
+        CategoryDtoResponse actual = categoryDtoResponseMapper.convert(new Category());
+
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
**Package:**  
`service/src/main/java/greencity/mapping`

###  Description

Write **unit tests** for all mapper classes in the `greencity.mapping` package.  
These classes convert between entity objects, DTOs, and VO (value objects), and are essential for ensuring proper separation between data models and API representations.


### Classes to Cover

- `CategoryDtoMapper` 
- `CategoryDtoResponseMapper` 

###  Test Scenarios

For each mapper:
- [ ] Convert from entity to DTO
- [ ] Convert from DTO to entity (if applicable)
- [ ] Handle null or empty input
- [ ] Validate that all fields are properly mapped
- [ ] Assert object equality using `assertEquals` or deep comparison libraries


###  Acceptance Criteria

- [ ] All tests pass successfully
- [ ] Tests follow Arrange-Act-Assert structure
- [ ] Mappers that use other dependencies (e.g., `ModelMapper`) are mocked or configured
- [ ] Corner cases like `null` or partially filled objects are tested
- [ ] **100% line and branch test coverage**
- [ ] Code is clean and adheres to project standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Introduced new test class `CategoryDtoMapperTest` to validate the conversion of `CategoryDto` to `Category` entity, covering both valid and empty input scenarios.
  - Added new test class `CategoryDtoResponseMapperTest` to ensure accurate mapping of `Category` entities to `CategoryDtoResponse`, including handling of null fields and default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->