### PR TITLE
[15] Created test classes for EcoNewsMapper

### DIFF
--- a/service/src/test/java/greencity/mapping/EcoNewsAuthorDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsAuthorDtoMapperTest.java
@@ -1,0 +1,36 @@
+package greencity.mapping;
+
+import greencity.dto.user.EcoNewsAuthorDto;
+import greencity.entity.User;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EcoNewsAuthorDtoMapperTest {
+
+    private final EcoNewsAuthorDtoMapper mapper = new EcoNewsAuthorDtoMapper();
+
+    @Test
+    void convert_MapUserToEcoNewsAuthorDto_Success() {
+
+        User user = new User();
+        user.setId(1L);
+        user.setName("John Doe");
+
+        EcoNewsAuthorDto dto = mapper.convert(user);
+
+        assertNotNull(dto);
+        assertEquals(1L, dto.getId());
+        assertEquals("John Doe", dto.getName());
+    }
+
+    @Test
+    void convert_NullUser_ThrowsNullPointerException() {
+        User user = new User();
+        EcoNewsAuthorDto dto = mapper.convert(user);
+
+        assertNotNull(dto);
+        assertNull(dto.getId());
+        assertNull(dto.getName());
+    }
+}

--- a/service/src/test/java/greencity/mapping/EcoNewsAuthorDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsAuthorDtoMapperTest.java
@@ -25,7 +25,7 @@ public class EcoNewsAuthorDtoMapperTest {
     }
 
     @Test
-    void convert_NullUser_ThrowsNullPointerException() {
+    void convert_UserWithNullProperties_ReturnsValidDtoWithNullProperties() {
         User user = new User();
         EcoNewsAuthorDto dto = mapper.convert(user);
 

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentDtoMapperTest.java
@@ -119,11 +119,11 @@ public class EcoNewsCommentDtoMapperTest {
         when(user.getId()).thenReturn(1L);
         when(user.getName()).thenReturn("John Doe");
         when(user.getProfilePicturePath()).thenReturn("/path/to/profile/pic");
+
         User user2 = mock(User.class);
-        when(ecoNewsComment.getUser()).thenReturn(user);
-        when(user.getId()).thenReturn(1L);
-        when(user.getName()).thenReturn("John Doe");
-        when(user.getProfilePicturePath()).thenReturn("/path/to/profile/pic");
+        when(user2.getId()).thenReturn(2L);
+        when(user2.getName()).thenReturn("Jane Smith");
+        when(user2.getProfilePicturePath()).thenReturn("/path/to/another/pic");
 
         Set<User> usersLiked = new HashSet<>();
         usersLiked.add(user);

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentDtoMapperTest.java
@@ -1,0 +1,152 @@
+package greencity.mapping;
+
+import greencity.dto.econewscomment.EcoNewsCommentDto;
+import greencity.entity.EcoNewsComment;
+import greencity.entity.User;
+import greencity.enums.CommentStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+public class EcoNewsCommentDtoMapperTest {
+
+    private EcoNewsCommentDtoMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mapper = new EcoNewsCommentDtoMapper();
+    }
+
+    @Test
+    void convert_DeletedComment_ReturnsDtoWithDeletedStatus() {
+
+        EcoNewsComment ecoNewsComment = mock(EcoNewsComment.class);
+        when(ecoNewsComment.isDeleted()).thenReturn(true);
+
+        EcoNewsCommentDto dto = mapper.convert(ecoNewsComment);
+
+        assertEquals(CommentStatus.DELETED, dto.getStatus());
+        verify(ecoNewsComment, times(1)).isDeleted();
+    }
+
+    @Test
+    void convert_OriginalComment_ReturnsDtoWithOriginalStatus() {
+
+        EcoNewsComment ecoNewsComment = mock(EcoNewsComment.class);
+        when(ecoNewsComment.isDeleted()).thenReturn(false);
+        LocalDateTime createdDate = LocalDateTime.now();
+        when(ecoNewsComment.getCreatedDate()).thenReturn(createdDate);
+        when(ecoNewsComment.getModifiedDate()).thenReturn(createdDate);
+        when(ecoNewsComment.getText()).thenReturn("This is a comment");
+
+        User user = mock(User.class);
+        when(ecoNewsComment.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(1L);
+        when(user.getName()).thenReturn("John Doe");
+        when(user.getProfilePicturePath()).thenReturn("/path/to/profile/pic");
+
+        Set<User> likedUsers = new HashSet<>();
+        when(ecoNewsComment.getUsersLiked()).thenReturn(likedUsers);
+        when(ecoNewsComment.isCurrentUserLiked()).thenReturn(false);
+
+        EcoNewsCommentDto dto = mapper.convert(ecoNewsComment);
+
+        assertEquals(CommentStatus.ORIGINAL, dto.getStatus());
+        assertEquals("This is a comment", dto.getText());
+        assertEquals(1L, dto.getAuthor().getId());
+        assertEquals("John Doe", dto.getAuthor().getName());
+        assertEquals("/path/to/profile/pic", dto.getAuthor().getUserProfilePicturePath());
+        assertEquals(0, dto.getLikes());
+        assertFalse(dto.isCurrentUserLiked());
+    }
+
+    @Test
+    void convert_EditedComment_ReturnsDtoWithEditedStatus() {
+
+        EcoNewsComment ecoNewsComment = mock(EcoNewsComment.class);
+
+        LocalDateTime createdDate = LocalDateTime.now().minusDays(1);
+        LocalDateTime modifiedDate = LocalDateTime.now();
+
+        when(ecoNewsComment.isDeleted()).thenReturn(false);
+        when(ecoNewsComment.getCreatedDate()).thenReturn(createdDate);
+        when(ecoNewsComment.getModifiedDate()).thenReturn(modifiedDate);
+        when(ecoNewsComment.getText()).thenReturn("This is an edited comment");
+
+        User user = mock(User.class);
+        when(ecoNewsComment.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(1L);
+        when(user.getName()).thenReturn("John Doe");
+        when(user.getProfilePicturePath()).thenReturn("/path/to/profile/pic");
+
+        Set<User> likedUsers = new HashSet<>();
+        when(ecoNewsComment.getUsersLiked()).thenReturn(likedUsers);
+        when(ecoNewsComment.isCurrentUserLiked()).thenReturn(false);
+
+        EcoNewsCommentDto dto = mapper.convert(ecoNewsComment);
+
+        assertEquals(CommentStatus.EDITED, dto.getStatus());
+        assertEquals("This is an edited comment", dto.getText());
+        assertEquals(1L, dto.getAuthor().getId());
+        assertEquals("John Doe", dto.getAuthor().getName());
+        assertEquals("/path/to/profile/pic", dto.getAuthor().getUserProfilePicturePath());
+        assertEquals(0, dto.getLikes());
+        assertFalse(dto.isCurrentUserLiked());
+    }
+
+    @Test
+    void convert_ValidComment_ReturnsDtoWithCorrectData() {
+
+        EcoNewsComment ecoNewsComment = mock(EcoNewsComment.class);
+        LocalDateTime createdDate = LocalDateTime.now().minusDays(1);
+        LocalDateTime modifiedDate = LocalDateTime.now();
+
+        when(ecoNewsComment.isDeleted()).thenReturn(false);
+        when(ecoNewsComment.getCreatedDate()).thenReturn(createdDate);
+        when(ecoNewsComment.getModifiedDate()).thenReturn(modifiedDate);
+        when(ecoNewsComment.getText()).thenReturn("This is a comment");
+
+        User user = mock(User.class);
+        when(ecoNewsComment.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(1L);
+        when(user.getName()).thenReturn("John Doe");
+        when(user.getProfilePicturePath()).thenReturn("/path/to/profile/pic");
+        User user2 = mock(User.class);
+        when(ecoNewsComment.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(1L);
+        when(user.getName()).thenReturn("John Doe");
+        when(user.getProfilePicturePath()).thenReturn("/path/to/profile/pic");
+
+        Set<User> usersLiked = new HashSet<>();
+        usersLiked.add(user);
+        usersLiked.add(user2);
+        when(ecoNewsComment.getUsersLiked()).thenReturn(usersLiked);
+
+        when(ecoNewsComment.isCurrentUserLiked()).thenReturn(true);
+
+        EcoNewsCommentDto dto = mapper.convert(ecoNewsComment);
+
+        System.out.println("Liked users count: " + ecoNewsComment.getUsersLiked().size());
+
+        assertEquals("This is a comment", dto.getText());
+        assertEquals(1L, dto.getAuthor().getId());
+        assertEquals("John Doe", dto.getAuthor().getName());
+        assertEquals("/path/to/profile/pic", dto.getAuthor().getUserProfilePicturePath());
+        assertEquals(2, dto.getLikes());
+        assertTrue(dto.isCurrentUserLiked());
+        assertEquals(CommentStatus.EDITED, dto.getStatus());
+    }
+
+    @Test
+    void convert_NullComment_ThrowsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.convert((EcoNewsComment) null));
+    }
+}

--- a/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsCommentVOMapperTest.java
@@ -1,0 +1,139 @@
+package greencity.mapping;
+
+import greencity.dto.econewscomment.EcoNewsCommentVO;
+import greencity.dto.user.UserVO;
+import greencity.entity.EcoNews;
+import greencity.entity.EcoNewsComment;
+import greencity.entity.User;
+import greencity.enums.Role;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@ExtendWith(MockitoExtension.class)
+public class EcoNewsCommentVOMapperTest {
+
+    @InjectMocks
+    private EcoNewsCommentVOMapper mapper;
+
+    @Test
+    void convert_FromEcoNewsCommentToEcoNewsCommentVO_WithoutParentComment() {
+
+        User user = User.builder()
+                .id(1L)
+                .role(Role.ROLE_USER)
+                .name("Test User")
+                .build();
+
+        EcoNews ecoNews = EcoNews.builder()
+                .id(10L)
+                .build();
+
+        Set<User> likedUsers = new HashSet<>();
+        likedUsers.add(User.builder().id(2L).build());
+        likedUsers.add(User.builder().id(3L).build());
+
+        EcoNewsComment ecoNewsComment = EcoNewsComment.builder()
+                .id(5L)
+                .user(user)
+                .modifiedDate(LocalDateTime.now().minusDays(2))
+                .parentComment(null)
+                .text("Test comment")
+                .deleted(false)
+                .currentUserLiked(true)
+                .createdDate(LocalDateTime.now().minusDays(5))
+                .usersLiked(likedUsers)
+                .ecoNews(ecoNews)
+                .build();
+
+        EcoNewsCommentVO commentVO = mapper.convert(ecoNewsComment);
+
+        assertEquals(ecoNewsComment.getId(), commentVO.getId());
+        assertEquals(ecoNewsComment.getUser().getId(), commentVO.getUser().getId());
+        assertEquals(ecoNewsComment.getUser().getRole(), commentVO.getUser().getRole());
+        assertEquals(ecoNewsComment.getUser().getName(), commentVO.getUser().getName());
+        assertEquals(ecoNewsComment.getModifiedDate(), commentVO.getModifiedDate());
+        assertNull(commentVO.getParentComment());
+        assertEquals(ecoNewsComment.getText(), commentVO.getText());
+        assertEquals(ecoNewsComment.isDeleted(), commentVO.isDeleted());
+        assertEquals(ecoNewsComment.isCurrentUserLiked(), commentVO.isCurrentUserLiked());
+        assertEquals(ecoNewsComment.getCreatedDate(), commentVO.getCreatedDate());
+        assertEquals(ecoNewsComment.getUsersLiked().size(), commentVO.getUsersLiked().size());
+        assertEquals(ecoNewsComment.getUsersLiked().stream().map(User::getId).collect(Collectors.toSet()),
+                commentVO.getUsersLiked().stream().map(UserVO::getId).collect(Collectors.toSet()));
+        assertEquals(ecoNewsComment.getEcoNews().getId(), commentVO.getEcoNews().getId());
+    }
+
+    @Test
+    void convert_FromEcoNewsCommentToEcoNewsCommentVO_WithParentComment() {
+
+        User user = User.builder()
+                .id(1L)
+                .role(Role.ROLE_USER)
+                .name("Test User")
+                .build();
+
+        EcoNews ecoNews = EcoNews.builder()
+                .id(10L)
+                .build();
+
+        User parentUser = User.builder()
+                .id(4L)
+                .role(Role.ROLE_MODERATOR)
+                .name("Parent User")
+                .build();
+
+        EcoNewsComment parentComment = EcoNewsComment.builder()
+                .id(6L)
+                .user(parentUser)
+                .modifiedDate(LocalDateTime.now().minusDays(3))
+                .parentComment(null)
+                .text("Parent comment")
+                .deleted(false)
+                .currentUserLiked(false)
+                .createdDate(LocalDateTime.now().minusDays(6))
+                .usersLiked(new HashSet<>())
+                .ecoNews(ecoNews)
+                .build();
+
+        EcoNewsComment ecoNewsComment = EcoNewsComment.builder()
+                .id(5L)
+                .user(user)
+                .modifiedDate(LocalDateTime.now().minusDays(2))
+                .parentComment(parentComment)
+                .text("Test comment with parent")
+                .deleted(false)
+                .currentUserLiked(true)
+                .createdDate(LocalDateTime.now().minusDays(5))
+                .usersLiked(new HashSet<>())
+                .ecoNews(ecoNews)
+                .build();
+
+        EcoNewsCommentVO commentVO = mapper.convert(ecoNewsComment);
+
+        assertEquals(ecoNewsComment.getId(), commentVO.getId());
+        assertEquals(ecoNewsComment.getUser().getId(), commentVO.getUser().getId());
+        assertEquals(ecoNewsComment.getUser().getRole(), commentVO.getUser().getRole());
+        assertEquals(ecoNewsComment.getUser().getName(), commentVO.getUser().getName());
+        assertEquals(ecoNewsComment.getModifiedDate(), commentVO.getModifiedDate());
+        assertEquals(parentComment.getId(), commentVO.getParentComment().getId());
+        assertEquals(parentComment.getUser().getId(), commentVO.getParentComment().getUser().getId());
+        assertEquals(parentComment.getUser().getRole(), commentVO.getParentComment().getUser().getRole());
+        assertEquals(parentComment.getUser().getName(), commentVO.getParentComment().getUser().getName());
+        assertNull(commentVO.getParentComment().getParentComment());
+        assertEquals(ecoNewsComment.getText(), commentVO.getText());
+        assertEquals(ecoNewsComment.isDeleted(), commentVO.isDeleted());
+        assertEquals(ecoNewsComment.isCurrentUserLiked(), commentVO.isCurrentUserLiked());
+        assertEquals(ecoNewsComment.getCreatedDate(), commentVO.getCreatedDate());
+        assertEquals(ecoNewsComment.getEcoNews().getId(), commentVO.getEcoNews().getId());
+    }
+}

--- a/service/src/test/java/greencity/mapping/EcoNewsDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsDtoMapperTest.java
@@ -1,0 +1,219 @@
+package greencity.mapping;
+
+import greencity.constant.AppConstant;
+import greencity.dto.econews.EcoNewsDto;
+import greencity.entity.*;
+import greencity.entity.localization.TagTranslation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class EcoNewsDtoMapperTest {
+
+    @InjectMocks
+    private EcoNewsDtoMapper mapper;
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsDto_DefaultLanguage() {
+
+        User author = User.builder().id(1L).name("John Doe").build();
+        Language enLanguage = Language.builder().code(AppConstant.DEFAULT_LANGUAGE_CODE).build();
+        Language uaLanguage = Language.builder().code("ua").build();
+
+        List<Tag> tags = new ArrayList<>();
+        Tag tag1 = Tag.builder().id(10L).build();
+        tag1.setTagTranslations(List.of(
+                TagTranslation.builder().name("news").language(enLanguage).build(),
+                TagTranslation.builder().name("новини").language(uaLanguage).build()
+        ));
+        Tag tag2 = Tag.builder().id(11L).build();
+        tag2.setTagTranslations(List.of(
+                TagTranslation.builder().name("environment").language(enLanguage).build(),
+                TagTranslation.builder().name("довкілля").language(uaLanguage).build()
+        ));
+        tags.add(tag1);
+        tags.add(tag2);
+
+        Set<User> likedUsers = new HashSet<>();
+        likedUsers.add(User.builder().id(2L).build());
+        likedUsers.add(User.builder().id(3L).build());
+
+        Set<User> dislikedUsers = new HashSet<>();
+        dislikedUsers.add(User.builder().id(4L).build());
+
+        List<EcoNewsComment> comments = new ArrayList<>();
+        comments.add(EcoNewsComment.builder().id(15L).deleted(false).build());
+        comments.add(EcoNewsComment.builder().id(16L).deleted(true).build());
+        comments.add(EcoNewsComment.builder().id(17L).deleted(false).build());
+
+        EcoNews ecoNews = EcoNews.builder()
+                .id(5L)
+                .author(author)
+                .text("Test content")
+                .creationDate(ZonedDateTime.now().minusDays(3))
+                .imagePath("/images/test.jpg")
+                .usersLikedNews(likedUsers)
+                .shortInfo("Short test info")
+                .tags(tags)
+                .usersDislikedNews(dislikedUsers)
+                .title("Test Title")
+                .ecoNewsComments(comments)
+                .build();
+
+        EcoNewsDto ecoNewsDto = mapper.convert(ecoNews);
+
+        assertEquals(ecoNews.getId(), ecoNewsDto.getId());
+        assertEquals(ecoNews.getAuthor().getId(), ecoNewsDto.getAuthor().getId());
+        assertEquals(ecoNews.getAuthor().getName(), ecoNewsDto.getAuthor().getName());
+        assertEquals(ecoNews.getText(), ecoNewsDto.getContent());
+        assertEquals(ecoNews.getCreationDate(), ecoNewsDto.getCreationDate());
+        assertEquals(ecoNews.getImagePath(), ecoNewsDto.getImagePath());
+        assertEquals(ecoNews.getUsersLikedNews().size(), ecoNewsDto.getLikes());
+        assertEquals(ecoNews.getShortInfo(), ecoNewsDto.getShortInfo());
+        assertEquals(List.of("news", "environment"), ecoNewsDto.getTags());
+        assertEquals(List.of("новини", "довкілля"), ecoNewsDto.getTagsUa());
+        assertEquals(ecoNews.getUsersDislikedNews().size(), ecoNewsDto.getDislikes());
+        assertEquals(ecoNews.getTitle(), ecoNewsDto.getTitle());
+        assertEquals(2, ecoNewsDto.getCountComments());
+    }
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsDto_NoTags() {
+
+        User author = User.builder().id(6L).name("Jane Smith").build();
+        EcoNews ecoNews = EcoNews.builder()
+                .id(6L)
+                .author(author)
+                .text("Another content")
+                .creationDate(ZonedDateTime.of(LocalDateTime.now().minusHours(10), ZoneId.of("Europe/Kyiv")))
+                .imagePath(null)
+                .usersLikedNews(Collections.emptySet())
+                .shortInfo("Another short info")
+                .tags(Collections.emptyList())
+                .usersDislikedNews(Collections.emptySet())
+                .title("Another Title")
+                .ecoNewsComments(Collections.emptyList())
+                .build();
+
+        EcoNewsDto ecoNewsDto = mapper.convert(ecoNews);
+
+        assertEquals(ecoNews.getId(), ecoNewsDto.getId());
+        assertEquals(ecoNews.getAuthor().getId(), ecoNewsDto.getAuthor().getId());
+        assertEquals(ecoNews.getAuthor().getName(), ecoNewsDto.getAuthor().getName());
+        assertEquals(ecoNews.getText(), ecoNewsDto.getContent());
+        assertEquals(ecoNews.getCreationDate(), ecoNewsDto.getCreationDate());
+        assertEquals(ecoNews.getImagePath(), ecoNewsDto.getImagePath());
+        assertEquals(0, ecoNewsDto.getLikes());
+        assertEquals(ecoNews.getShortInfo(), ecoNewsDto.getShortInfo());
+        assertEquals(Collections.emptyList(), ecoNewsDto.getTags());
+        assertEquals(Collections.emptyList(), ecoNewsDto.getTagsUa());
+        assertEquals(0, ecoNewsDto.getDislikes());
+        assertEquals(ecoNews.getTitle(), ecoNewsDto.getTitle());
+        assertEquals(0, ecoNewsDto.getCountComments());
+    }
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsDto_NoComments() {
+
+        User author = User.builder().id(7L).name("Peter Pan").build();
+        EcoNews ecoNews = EcoNews.builder()
+                .id(8L)
+                .author(author)
+                .text("Content without comments")
+                .creationDate(ZonedDateTime.of(LocalDateTime.now().minusDays(1), ZoneId.of("Europe/Kyiv")))
+                .imagePath("/image.png")
+                .usersLikedNews(Set.of(User.builder().id(9L).build()))
+                .shortInfo("Info without comments")
+                .tags(Collections.emptyList())
+                .usersDislikedNews(Set.of(User.builder().id(10L).build()))
+                .title("Title without comments")
+                .ecoNewsComments(Collections.emptyList())
+                .build();
+
+        EcoNewsDto ecoNewsDto = mapper.convert(ecoNews);
+
+        assertEquals(ecoNews.getId(), ecoNewsDto.getId());
+        assertEquals(ecoNews.getAuthor().getId(), ecoNewsDto.getAuthor().getId());
+        assertEquals(ecoNews.getAuthor().getName(), ecoNewsDto.getAuthor().getName());
+        assertEquals(ecoNews.getText(), ecoNewsDto.getContent());
+        assertEquals(ecoNews.getCreationDate(), ecoNewsDto.getCreationDate());
+        assertEquals(ecoNews.getImagePath(), ecoNewsDto.getImagePath());
+        assertEquals(1, ecoNewsDto.getLikes());
+        assertEquals(ecoNews.getShortInfo(), ecoNewsDto.getShortInfo());
+        assertEquals(Collections.emptyList(), ecoNewsDto.getTags());
+        assertEquals(Collections.emptyList(), ecoNewsDto.getTagsUa());
+        assertEquals(1, ecoNewsDto.getDislikes());
+        assertEquals(ecoNews.getTitle(), ecoNewsDto.getTitle());
+        assertEquals(0, ecoNewsDto.getCountComments());
+    }
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsDto_OnlyDefaultLanguageTags() {
+
+        User author = User.builder().id(11L).name("Alice").build();
+        Language enLanguage = Language.builder().code(AppConstant.DEFAULT_LANGUAGE_CODE).build();
+        List<Tag> tags = new ArrayList<>();
+        Tag tag = Tag.builder().id(20L).build();
+        tag.setTagTranslations(List.of(TagTranslation.builder().name("global").language(enLanguage).build()));
+        tags.add(tag);
+
+        EcoNews ecoNews = EcoNews.builder()
+                .id(12L)
+                .author(author)
+                .text("Default lang tags")
+                .creationDate(ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("Europe/Kyiv")))
+                .imagePath("/image2.png")
+                .usersLikedNews(Collections.singleton(User.builder().id(13L).build()))
+                .shortInfo("Default tags info")
+                .tags(tags)
+                .usersDislikedNews(Collections.emptySet())
+                .title("Default Tags Title")
+                .ecoNewsComments(Collections.emptyList())
+                .build();
+
+        EcoNewsDto ecoNewsDto = mapper.convert(ecoNews);
+
+        assertEquals(List.of("global"), ecoNewsDto.getTags());
+        assertEquals(Collections.emptyList(), ecoNewsDto.getTagsUa());
+    }
+
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsDto_OnlyUaLanguageTags() {
+
+        User author = User.builder().id(14L).name("Bob").build();
+        Language uaLanguage = Language.builder().code("ua").build();
+        List<Tag> tags = new ArrayList<>();
+        Tag tag = Tag.builder().id(21L).build();
+        tag.setTagTranslations(List.of(TagTranslation.builder().name("світ").language(uaLanguage).build()));
+        tags.add(tag);
+
+        EcoNews ecoNews = EcoNews.builder()
+                .id(15L)
+                .author(author)
+                .text("Ua lang tags")
+                .creationDate(ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("Europe/Kyiv")))
+                .imagePath("/image3.png")
+                .usersLikedNews(Collections.emptySet())
+                .shortInfo("Ua tags info")
+                .tags(tags)
+                .usersDislikedNews(Collections.singleton(User.builder().id(16L).build()))
+                .title("Ua Tags Title")
+                .ecoNewsComments(Collections.emptyList())
+                .build();
+
+        EcoNewsDto ecoNewsDto = mapper.convert(ecoNews);
+
+        assertEquals(Collections.emptyList(), ecoNewsDto.getTags());
+        assertEquals(List.of("світ"), ecoNewsDto.getTagsUa());
+    }
+}

--- a/service/src/test/java/greencity/mapping/EcoNewsVOMapperTest.java
+++ b/service/src/test/java/greencity/mapping/EcoNewsVOMapperTest.java
@@ -1,0 +1,210 @@
+package greencity.mapping;
+
+import greencity.dto.econews.EcoNewsVO;
+import greencity.dto.user.UserVO;
+import greencity.entity.*;
+import greencity.entity.localization.TagTranslation;
+import greencity.enums.Role;
+import greencity.enums.UserStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+public class EcoNewsVOMapperTest {
+
+    @InjectMocks
+    private EcoNewsVOMapper mapper;
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsVO_FullData() {
+
+        User author = User.builder().id(1L).name("John Doe").userStatus(UserStatus.ACTIVATED).role(Role.ROLE_USER).build();
+        Language enLanguage = Language.builder().id(1L).code("en").build();
+        Language uaLanguage = Language.builder().id(2L).code("ua").build();
+
+        List<Tag> tags = new ArrayList<>();
+        Tag tag1 = Tag.builder().id(10L).build();
+        tag1.setTagTranslations(List.of(
+                TagTranslation.builder().id(100L).name("news").language(enLanguage).tag(tag1).build(),
+                TagTranslation.builder().id(101L).name("новини").language(uaLanguage).tag(tag1).build()
+        ));
+        Tag tag2 = Tag.builder().id(11L).build();
+        tag2.setTagTranslations(List.of(
+                TagTranslation.builder().id(102L).name("environment").language(enLanguage).tag(tag2).build(),
+                TagTranslation.builder().id(103L).name("довкілля").language(uaLanguage).tag(tag2).build()
+        ));
+        tags.add(tag1);
+        tags.add(tag2);
+
+        Set<User> likedUsers = Set.of(User.builder().id(2L).build(), User.builder().id(3L).build());
+        Set<User> dislikedUsers = Set.of(User.builder().id(4L).build());
+
+        List<EcoNewsComment> comments = new ArrayList<>();
+        EcoNewsComment comment1 = EcoNewsComment.builder().id(15L).createdDate(LocalDateTime.now().minusDays(2)).currentUserLiked(true).deleted(false).text("Comment 1").modifiedDate(LocalDateTime.now().minusDays(1)).user(User.builder().id(5L).name("Commenter 1").userStatus(UserStatus.CREATED).role(Role.ROLE_MODERATOR).build()).build();
+        EcoNewsComment comment2 = EcoNewsComment.builder().id(16L).createdDate(LocalDateTime.now().minusDays(5)).currentUserLiked(false).deleted(true).text("Comment 2").modifiedDate(LocalDateTime.now().minusDays(4)).user(User.builder().id(6L).name("Commenter 2").userStatus(UserStatus.BLOCKED).role(Role.ROLE_ADMIN).build()).build();
+        comments.add(comment1);
+        comments.add(comment2);
+
+        EcoNews ecoNews = EcoNews.builder()
+                .id(5L)
+                .author(author)
+                .creationDate(ZonedDateTime.now().minusDays(3))
+                .imagePath("/images/test.jpg")
+                .source("Test Source")
+                .text("Test content")
+                .title("Test Title")
+                .tags(tags)
+                .usersLikedNews(likedUsers)
+                .usersDislikedNews(dislikedUsers)
+                .ecoNewsComments(comments)
+                .build();
+
+        EcoNewsVO ecoNewsVO = mapper.convert(ecoNews);
+
+        assertNotNull(ecoNewsVO);
+        assertEquals(ecoNews.getId(), ecoNewsVO.getId());
+        assertEquals(ecoNews.getAuthor().getId(), ecoNewsVO.getAuthor().getId());
+        assertEquals(ecoNews.getAuthor().getName(), ecoNewsVO.getAuthor().getName());
+        assertEquals(ecoNews.getAuthor().getUserStatus(), ecoNewsVO.getAuthor().getUserStatus());
+        assertEquals(ecoNews.getAuthor().getRole(), ecoNewsVO.getAuthor().getRole());
+        assertEquals(ecoNews.getCreationDate(), ecoNewsVO.getCreationDate());
+        assertEquals(ecoNews.getImagePath(), ecoNewsVO.getImagePath());
+        assertEquals(ecoNews.getSource(), ecoNewsVO.getSource());
+        assertEquals(ecoNews.getText(), ecoNewsVO.getText());
+        assertEquals(ecoNews.getTitle(), ecoNewsVO.getTitle());
+        assertEquals(ecoNews.getTags().size(), ecoNewsVO.getTags().size());
+        assertEquals(ecoNews.getUsersLikedNews().size(), ecoNewsVO.getUsersLikedNews().size());
+        assertEquals(ecoNews.getUsersDislikedNews().size(), ecoNewsVO.getUsersDislikedNews().size());
+        assertEquals(ecoNews.getEcoNewsComments().size(), ecoNewsVO.getEcoNewsComments().size());
+
+        assertEquals(ecoNews.getTags().getFirst().getId(), ecoNewsVO.getTags().getFirst().getId());
+        assertEquals(ecoNews.getTags().getFirst().getTagTranslations().size(), ecoNewsVO.getTags().getFirst().getTagTranslations().size());
+        assertEquals(ecoNews.getTags().getFirst().getTagTranslations().getFirst().getName(), ecoNewsVO.getTags().getFirst().getTagTranslations().getFirst().getName());
+        assertEquals(ecoNews.getTags().getFirst().getTagTranslations().getFirst().getLanguage().getCode(), ecoNewsVO.getTags().getFirst().getTagTranslations().getFirst().getLanguageVO().getCode());
+
+        assertEquals(ecoNews.getUsersLikedNews().stream().map(User::getId).collect(Collectors.toSet()),
+                ecoNewsVO.getUsersLikedNews().stream().map(UserVO::getId).collect(Collectors.toSet()));
+
+        assertEquals(ecoNews.getUsersDislikedNews().stream().map(User::getId).collect(Collectors.toSet()),
+                ecoNewsVO.getUsersDislikedNews().stream().map(UserVO::getId).collect(Collectors.toSet()));
+
+        assertEquals(ecoNews.getEcoNewsComments().getFirst().getId(), ecoNewsVO.getEcoNewsComments().getFirst().getId());
+        assertEquals(ecoNews.getEcoNewsComments().getFirst().getCreatedDate(), ecoNewsVO.getEcoNewsComments().getFirst().getCreatedDate());
+        assertEquals(ecoNews.getEcoNewsComments().getFirst().isCurrentUserLiked(), ecoNewsVO.getEcoNewsComments().getFirst().isCurrentUserLiked());
+        assertEquals(ecoNews.getEcoNewsComments().getFirst().isDeleted(), ecoNewsVO.getEcoNewsComments().getFirst().isDeleted());
+        assertEquals(ecoNews.getEcoNewsComments().getFirst().getText(), ecoNewsVO.getEcoNewsComments().getFirst().getText());
+        assertEquals(ecoNews.getEcoNewsComments().getFirst().getModifiedDate(), ecoNewsVO.getEcoNewsComments().getFirst().getModifiedDate());
+        assertEquals(ecoNews.getEcoNewsComments().getFirst().getUser().getId(), ecoNewsVO.getEcoNewsComments().getFirst().getUser().getId());
+        assertEquals(ecoNews.getEcoNewsComments().getFirst().getUser().getName(), ecoNewsVO.getEcoNewsComments().getFirst().getUser().getName());
+    }
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsVO_MinimalData() {
+
+        User author = User.builder().id(1L).name("John Doe").build();
+        EcoNews ecoNews = EcoNews.builder()
+                .id(5L)
+                .author(author)
+                .creationDate(ZonedDateTime.now().minusDays(3))
+                .title("Test Title")
+                .text("Test content")
+                .tags(Collections.emptyList())
+                .usersLikedNews(Collections.emptySet())
+                .usersDislikedNews(Collections.emptySet())
+                .ecoNewsComments(Collections.emptyList())
+                .build();
+
+        EcoNewsVO ecoNewsVO = mapper.convert(ecoNews);
+
+        assertNotNull(ecoNewsVO);
+        assertEquals(ecoNews.getId(), ecoNewsVO.getId());
+        assertEquals(ecoNews.getAuthor().getId(), ecoNewsVO.getAuthor().getId());
+        assertEquals(ecoNews.getAuthor().getName(), ecoNewsVO.getAuthor().getName());
+        assertEquals(ecoNews.getCreationDate(), ecoNewsVO.getCreationDate());
+        assertEquals(ecoNews.getTitle(), ecoNewsVO.getTitle());
+        assertEquals(ecoNews.getText(), ecoNewsVO.getText());
+        assertEquals(Collections.emptyList(), ecoNewsVO.getTags());
+        assertEquals(Collections.emptySet(), ecoNewsVO.getUsersLikedNews());
+        assertEquals(Collections.emptySet(), ecoNewsVO.getUsersDislikedNews());
+        assertEquals(Collections.emptyList(), ecoNewsVO.getEcoNewsComments());
+    }
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsVO_WithNullOptionalFields() {
+
+        User author = User.builder().id(1L).name("John Doe").build();
+        EcoNews ecoNews = EcoNews.builder()
+                .id(5L)
+                .author(author)
+                .creationDate(ZonedDateTime.now().minusDays(3))
+                .title("Test Title")
+                .text("Test content")
+                .tags(Collections.emptyList())
+                .imagePath(null)
+                .source(null)
+                .usersLikedNews(Collections.emptySet())
+                .usersDislikedNews(Collections.emptySet())
+                .ecoNewsComments(Collections.emptyList())
+                .build();
+
+        EcoNewsVO ecoNewsVO = mapper.convert(ecoNews);
+
+        assertNotNull(ecoNewsVO);
+        assertEquals(ecoNews.getId(), ecoNewsVO.getId());
+        assertEquals(ecoNews.getAuthor().getId(), ecoNewsVO.getAuthor().getId());
+        assertEquals(ecoNews.getAuthor().getName(), ecoNewsVO.getAuthor().getName());
+        assertEquals(ecoNews.getCreationDate(), ecoNewsVO.getCreationDate());
+        assertEquals(ecoNews.getTitle(), ecoNewsVO.getTitle());
+        assertEquals(ecoNews.getText(), ecoNewsVO.getText());
+        assertEquals(Collections.emptyList(), ecoNewsVO.getTags());
+        assertEquals(Collections.emptySet(), ecoNewsVO.getUsersLikedNews());
+        assertEquals(Collections.emptySet(), ecoNewsVO.getUsersDislikedNews());
+        assertEquals(Collections.emptyList(), ecoNewsVO.getEcoNewsComments());
+        assertEquals(ecoNews.getImagePath(), ecoNewsVO.getImagePath());
+        assertEquals(ecoNews.getSource(), ecoNewsVO.getSource());
+    }
+
+    @Test
+    void convert_FromEcoNewsToEcoNewsVO_WithoutTagsAndComments() {
+
+        User author = User.builder().id(1L).name("John Doe").build();
+        EcoNews ecoNews = EcoNews.builder()
+                .id(5L)
+                .author(author)
+                .creationDate(ZonedDateTime.now().minusDays(3))
+                .title("Test Title")
+                .text("Test content")
+                .usersLikedNews(Set.of(User.builder().id(2L).build()))
+                .usersDislikedNews(Set.of(User.builder().id(3L).build()))
+                .tags(Collections.emptyList())
+                .ecoNewsComments(Collections.emptyList())
+                .build();
+
+        EcoNewsVO ecoNewsVO = mapper.convert(ecoNews);
+
+        assertNotNull(ecoNewsVO);
+        assertEquals(ecoNews.getId(), ecoNewsVO.getId());
+        assertEquals(ecoNews.getAuthor().getId(), ecoNewsVO.getAuthor().getId());
+        assertEquals(ecoNews.getAuthor().getName(), ecoNewsVO.getAuthor().getName());
+        assertEquals(ecoNews.getCreationDate(), ecoNewsVO.getCreationDate());
+        assertEquals(ecoNews.getTitle(), ecoNewsVO.getTitle());
+        assertEquals(ecoNews.getText(), ecoNewsVO.getText());
+        assertEquals(Collections.emptyList(), ecoNewsVO.getTags());
+        assertEquals(ecoNews.getUsersLikedNews().size(), ecoNewsVO.getUsersLikedNews().size());
+        assertEquals(ecoNews.getUsersDislikedNews().size(), ecoNewsVO.getUsersDislikedNews().size());
+        assertEquals(Collections.emptyList(), ecoNewsVO.getEcoNewsComments());
+    }
+}


### PR DESCRIPTION
Added unit tests for all EcoNews mappers in the greencity.mapping package. Covered mappings between entities, DTOs, and VOs. Verified correct data transformation and handling of edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added new test classes to validate data conversions for various entities, including `EcoNews`, `EcoNewsComment`, and their respective DTOs, ensuring consistent and reliable content presentation.
	- Introduced unit tests for the `EcoNewsAuthorDtoMapper`, `EcoNewsCommentDtoMapper`, `EcoNewsCommentVOMapper`, `EcoNewsDtoMapper`, and `EcoNewsVOMapper` to cover various conversion scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->