### PR TITLE
[15] Created first part test classes for HabitMapper

### DIFF
--- a/service/src/test/java/greencity/mapping/HabitAssignDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitAssignDtoMapperTest.java
@@ -1,0 +1,165 @@
+package greencity.mapping;
+
+import greencity.dto.habit.HabitAssignDto;
+import greencity.dto.habitstatuscalendar.HabitStatusCalendarDto;
+import greencity.entity.Habit;
+import greencity.entity.HabitAssign;
+import greencity.entity.HabitStatusCalendar;
+import greencity.entity.User;
+import greencity.enums.HabitAssignStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class HabitAssignDtoMapperTest {
+
+    @InjectMocks
+    private HabitAssignDtoMapper mapper;
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignDto_FullData() {
+
+        User user = User.builder().id(1L).build();
+        Habit habit = Habit.builder().id(2L).build();
+        ZonedDateTime createDateTime = ZonedDateTime.of(LocalDateTime.now().minusDays(5), ZoneId.of("Europe/Kyiv"));
+        ZonedDateTime lastEnrollmentDate = ZonedDateTime.of(LocalDateTime.now().minusDays(1), ZoneId.of("Europe/Kyiv"));
+
+        HabitStatusCalendar calendar1 = HabitStatusCalendar.builder()
+                .id(10L)
+                .enrollDate(LocalDate.now().minusDays(4))
+                .habitAssign(HabitAssign.builder().id(5L).build())
+                .build();
+        HabitStatusCalendar calendar2 = HabitStatusCalendar.builder()
+                .id(11L)
+                .enrollDate(LocalDate.now().minusDays(3))
+                .habitAssign(HabitAssign.builder().id(5L).build())
+                .build();
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(5L)
+                .status(HabitAssignStatus.INPROGRESS)
+                .createDate(createDateTime)
+                .user(user)
+                .habit(habit)
+                .duration(30)
+                .workingDays(10)
+                .habitStreak(5)
+                .lastEnrollmentDate(lastEnrollmentDate)
+                .progressNotificationHasDisplayed(false)
+                .habitStatusCalendars(List.of(calendar1, calendar2))
+                .build();
+
+        HabitAssignDto habitAssignDto = mapper.convert(habitAssign);
+
+        assertNotNull(habitAssignDto);
+        assertEquals(habitAssign.getId(), habitAssignDto.getId());
+        assertEquals(habitAssign.getStatus(), habitAssignDto.getStatus());
+        assertEquals(habitAssign.getCreateDate(), habitAssignDto.getCreateDateTime());
+        assertEquals(habitAssign.getUser().getId(), habitAssignDto.getUserId());
+        assertEquals(habitAssign.getDuration(), habitAssignDto.getDuration());
+        assertEquals(habitAssign.getHabitStreak(), habitAssignDto.getHabitStreak());
+        assertEquals(habitAssign.getWorkingDays(), habitAssignDto.getWorkingDays());
+        assertEquals(habitAssign.getLastEnrollmentDate(), habitAssignDto.getLastEnrollmentDate());
+        assertEquals(habitAssign.getHabitStatusCalendars().size(), habitAssignDto.getHabitStatusCalendarDtoList().size());
+
+        List<Long> expectedCalendarIds = habitAssign.getHabitStatusCalendars().stream()
+                .map(HabitStatusCalendar::getId)
+                .collect(Collectors.toList());
+        List<Long> actualCalendarIds = habitAssignDto.getHabitStatusCalendarDtoList().stream()
+                .map(HabitStatusCalendarDto::getId)
+                .collect(Collectors.toList());
+        assertEquals(expectedCalendarIds, actualCalendarIds);
+
+        List<LocalDate> expectedEnrollDates = habitAssign.getHabitStatusCalendars().stream()
+                .map(HabitStatusCalendar::getEnrollDate)
+                .collect(Collectors.toList());
+        List<LocalDate> actualEnrollDates = habitAssignDto.getHabitStatusCalendarDtoList().stream()
+                .map(HabitStatusCalendarDto::getEnrollDate)
+                .collect(Collectors.toList());
+        assertEquals(expectedEnrollDates, actualEnrollDates);
+    }
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignDto_MinimalData() {
+
+        User user = User.builder().id(2L).build();
+        Habit habit = Habit.builder().id(3L).build();
+        ZonedDateTime createDateTime = ZonedDateTime.now();
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(6L)
+                .status(HabitAssignStatus.ACTIVE)
+                .createDate(createDateTime)
+                .user(user)
+                .habit(habit)
+                .duration(21)
+                .workingDays(0)
+                .habitStreak(0)
+                .lastEnrollmentDate(createDateTime)
+                .progressNotificationHasDisplayed(false)
+                .habitStatusCalendars(Collections.emptyList())
+                .build();
+
+        HabitAssignDto habitAssignDto = mapper.convert(habitAssign);
+
+        assertNotNull(habitAssignDto);
+        assertEquals(habitAssign.getId(), habitAssignDto.getId());
+        assertEquals(habitAssign.getStatus(), habitAssignDto.getStatus());
+        assertEquals(habitAssign.getCreateDate(), habitAssignDto.getCreateDateTime());
+        assertEquals(habitAssign.getUser().getId(), habitAssignDto.getUserId());
+        assertEquals(habitAssign.getDuration(), habitAssignDto.getDuration());
+        assertEquals(habitAssign.getHabitStreak(), habitAssignDto.getHabitStreak());
+        assertEquals(habitAssign.getWorkingDays(), habitAssignDto.getWorkingDays());
+        assertEquals(habitAssign.getLastEnrollmentDate(), habitAssignDto.getLastEnrollmentDate());
+        assertTrue(habitAssignDto.getHabitStatusCalendarDtoList().isEmpty());
+    }
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignDto_NoHabitStatusCalendars() {
+
+        User user = User.builder().id(3L).build();
+        Habit habit = Habit.builder().id(4L).build();
+        ZonedDateTime createDateTime = ZonedDateTime.now().minusHours(2);
+        ZonedDateTime lastEnrollmentDate = ZonedDateTime.now().minusDays(7);
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(7L)
+                .status(HabitAssignStatus.CANCELLED)
+                .createDate(createDateTime)
+                .user(user)
+                .habit(habit)
+                .duration(60)
+                .workingDays(30)
+                .habitStreak(15)
+                .lastEnrollmentDate(lastEnrollmentDate)
+                .progressNotificationHasDisplayed(true)
+                .habitStatusCalendars(Collections.emptyList())
+                .build();
+
+        HabitAssignDto habitAssignDto = mapper.convert(habitAssign);
+
+        assertNotNull(habitAssignDto);
+        assertEquals(habitAssign.getId(), habitAssignDto.getId());
+        assertEquals(habitAssign.getStatus(), habitAssignDto.getStatus());
+        assertEquals(habitAssign.getCreateDate(), habitAssignDto.getCreateDateTime());
+        assertEquals(habitAssign.getUser().getId(), habitAssignDto.getUserId());
+        assertEquals(habitAssign.getDuration(), habitAssignDto.getDuration());
+        assertEquals(habitAssign.getHabitStreak(), habitAssignDto.getHabitStreak());
+        assertEquals(habitAssign.getWorkingDays(), habitAssignDto.getWorkingDays());
+        assertEquals(habitAssign.getLastEnrollmentDate(), habitAssignDto.getLastEnrollmentDate());
+        assertNotNull(habitAssignDto.getHabitStatusCalendarDtoList());
+        assertTrue(habitAssignDto.getHabitStatusCalendarDtoList().isEmpty());
+    }
+}

--- a/service/src/test/java/greencity/mapping/HabitAssignManagementDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitAssignManagementDtoMapperTest.java
@@ -1,0 +1,129 @@
+package greencity.mapping;
+
+import greencity.dto.habit.HabitAssignManagementDto;
+import greencity.entity.Habit;
+import greencity.entity.HabitAssign;
+import greencity.entity.User;
+import greencity.enums.HabitAssignStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+public class HabitAssignManagementDtoMapperTest {
+
+    @InjectMocks
+    private HabitAssignManagementDtoMapper mapper;
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignManagementDto_FullData() {
+
+        User user = User.builder().id(1L).build();
+        Habit habit = Habit.builder().id(2L).build();
+        ZonedDateTime createDateTime = ZonedDateTime.of(LocalDateTime.now().minusDays(5), ZoneId.of("Europe/Kyiv"));
+        ZonedDateTime lastEnrollmentDate = ZonedDateTime.of(LocalDateTime.now().minusDays(1), ZoneId.of("Europe/Kyiv"));
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(5L)
+                .status(HabitAssignStatus.INPROGRESS)
+                .createDate(createDateTime)
+                .user(user)
+                .habit(habit)
+                .duration(30)
+                .workingDays(10)
+                .habitStreak(5)
+                .lastEnrollmentDate(lastEnrollmentDate)
+                .progressNotificationHasDisplayed(false)
+                .build();
+
+        HabitAssignManagementDto habitAssignManagementDto = mapper.convert(habitAssign);
+
+        assertNotNull(habitAssignManagementDto);
+        assertEquals(habitAssign.getId(), habitAssignManagementDto.getId());
+        assertEquals(habitAssign.getStatus(), habitAssignManagementDto.getStatus());
+        assertEquals(habitAssign.getCreateDate(), habitAssignManagementDto.getCreateDateTime());
+        assertEquals(habitAssign.getUser().getId(), habitAssignManagementDto.getUserId());
+        assertEquals(habitAssign.getHabit().getId(), habitAssignManagementDto.getHabitId());
+        assertEquals(habitAssign.getDuration(), habitAssignManagementDto.getDuration());
+        assertEquals(habitAssign.getHabitStreak(), habitAssignManagementDto.getHabitStreak());
+        assertEquals(habitAssign.getWorkingDays(), habitAssignManagementDto.getWorkingDays());
+        assertEquals(habitAssign.getLastEnrollmentDate(), habitAssignManagementDto.getLastEnrollment());
+    }
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignManagementDto_MinimalData() {
+
+        User user = User.builder().id(2L).build();
+        Habit habit = Habit.builder().id(3L).build();
+        ZonedDateTime createDateTime = ZonedDateTime.now();
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(6L)
+                .status(HabitAssignStatus.ACTIVE)
+                .createDate(createDateTime)
+                .user(user)
+                .habit(habit)
+                .duration(21)
+                .workingDays(0)
+                .habitStreak(0)
+                .lastEnrollmentDate(createDateTime)
+                .progressNotificationHasDisplayed(false)
+                .build();
+
+        HabitAssignManagementDto habitAssignManagementDto = mapper.convert(habitAssign);
+
+        assertNotNull(habitAssignManagementDto);
+        assertEquals(habitAssign.getId(), habitAssignManagementDto.getId());
+        assertEquals(habitAssign.getStatus(), habitAssignManagementDto.getStatus());
+        assertEquals(habitAssign.getCreateDate(), habitAssignManagementDto.getCreateDateTime());
+        assertEquals(habitAssign.getUser().getId(), habitAssignManagementDto.getUserId());
+        assertEquals(habitAssign.getHabit().getId(), habitAssignManagementDto.getHabitId());
+        assertEquals(habitAssign.getDuration(), habitAssignManagementDto.getDuration());
+        assertEquals(habitAssign.getHabitStreak(), habitAssignManagementDto.getHabitStreak());
+        assertEquals(habitAssign.getWorkingDays(), habitAssignManagementDto.getWorkingDays());
+        assertEquals(habitAssign.getLastEnrollmentDate(), habitAssignManagementDto.getLastEnrollment());
+    }
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignManagementDto_WithDifferentStatus() {
+
+        User user = User.builder().id(4L).build();
+        Habit habit = Habit.builder().id(5L).build();
+        ZonedDateTime createDateTime = ZonedDateTime.now().minusDays(10);
+        ZonedDateTime lastEnrollmentDate = ZonedDateTime.now().minusDays(2);
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(8L)
+                .status(HabitAssignStatus.ACQUIRED)
+                .createDate(createDateTime)
+                .user(user)
+                .habit(habit)
+                .duration(90)
+                .workingDays(60)
+                .habitStreak(90)
+                .lastEnrollmentDate(lastEnrollmentDate)
+                .progressNotificationHasDisplayed(true)
+                .build();
+
+        HabitAssignManagementDto habitAssignManagementDto = mapper.convert(habitAssign);
+
+        assertNotNull(habitAssignManagementDto);
+        assertEquals(habitAssign.getId(), habitAssignManagementDto.getId());
+        assertEquals(habitAssign.getStatus(), habitAssignManagementDto.getStatus());
+        assertEquals(habitAssign.getCreateDate(), habitAssignManagementDto.getCreateDateTime());
+        assertEquals(habitAssign.getUser().getId(), habitAssignManagementDto.getUserId());
+        assertEquals(habitAssign.getHabit().getId(), habitAssignManagementDto.getHabitId());
+        assertEquals(habitAssign.getDuration(), habitAssignManagementDto.getDuration());
+        assertEquals(habitAssign.getHabitStreak(), habitAssignManagementDto.getHabitStreak());
+        assertEquals(habitAssign.getWorkingDays(), habitAssignManagementDto.getWorkingDays());
+        assertEquals(habitAssign.getLastEnrollmentDate(), habitAssignManagementDto.getLastEnrollment());
+    }
+}

--- a/service/src/test/java/greencity/mapping/HabitAssignMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitAssignMapperTest.java
@@ -1,0 +1,203 @@
+package greencity.mapping;
+
+import greencity.dto.habit.HabitAssignDto;
+import greencity.dto.habit.HabitDto;
+import greencity.dto.user.UserShoppingListItemAdvanceDto;
+import greencity.entity.HabitAssign;
+import greencity.entity.UserShoppingListItem;
+import greencity.enums.HabitAssignStatus;
+import greencity.enums.ShoppingListItemStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class HabitAssignMapperTest {
+
+    @InjectMocks
+    private HabitAssignMapper mapper;
+
+    @Test
+    void convert_FromHabitAssignDtoToHabitAssign_FullDataWithShoppingListItems() {
+
+        ZonedDateTime createDateTime = ZonedDateTime.of(LocalDateTime.now().minusDays(3), ZoneId.of("Europe/Kyiv"));
+        ZonedDateTime lastEnrollmentDate = ZonedDateTime.of(LocalDateTime.now().minusDays(1), ZoneId.of("Europe/Kyiv"));
+
+        UserShoppingListItemAdvanceDto item1 = UserShoppingListItemAdvanceDto.builder()
+                .id(10L)
+                .dateCompleted(LocalDateTime.now().minusDays(2))
+                .status(ShoppingListItemStatus.INPROGRESS)
+                .shoppingListItemId(100L)
+                .build();
+        UserShoppingListItemAdvanceDto item2 = UserShoppingListItemAdvanceDto.builder()
+                .id(11L)
+                .dateCompleted(LocalDateTime.now())
+                .status(ShoppingListItemStatus.DONE)
+                .shoppingListItemId(101L)
+                .build();
+
+        HabitDto habitDto = HabitDto.builder().id(5L).complexity(2).build();
+
+        HabitAssignDto habitAssignDto = HabitAssignDto.builder()
+                .id(15L)
+                .duration(30)
+                .habitStreak(7)
+                .createDateTime(createDateTime)
+                .status(HabitAssignStatus.INPROGRESS)
+                .workingDays(15)
+                .lastEnrollmentDate(lastEnrollmentDate)
+                .habit(habitDto)
+                .userShoppingListItems(List.of(item1, item2))
+                .build();
+
+        HabitAssign habitAssign = mapper.convert(habitAssignDto);
+
+        assertNotNull(habitAssign);
+        assertEquals(habitAssignDto.getId(), habitAssign.getId());
+        assertEquals(habitAssignDto.getDuration(), habitAssign.getDuration());
+        assertEquals(habitAssignDto.getHabitStreak(), habitAssign.getHabitStreak());
+        assertEquals(habitAssignDto.getCreateDateTime(), habitAssign.getCreateDate());
+        assertEquals(habitAssignDto.getStatus(), habitAssign.getStatus());
+        assertEquals(habitAssignDto.getWorkingDays(), habitAssign.getWorkingDays());
+        assertEquals(habitAssignDto.getLastEnrollmentDate(), habitAssign.getLastEnrollmentDate());
+
+        assertNotNull(habitAssign.getHabit());
+        assertEquals(habitAssignDto.getHabit().getId(), habitAssign.getHabit().getId());
+        assertEquals(habitAssignDto.getHabit().getComplexity(), habitAssign.getHabit().getComplexity());
+        assertEquals(habitAssignDto.getDuration(), habitAssign.getHabit().getDefaultDuration());
+
+        assertNotNull(habitAssign.getUserShoppingListItems());
+        assertEquals(1, habitAssign.getUserShoppingListItems().size());
+
+        UserShoppingListItem mappedItem = habitAssign.getUserShoppingListItems().getFirst();
+        assertEquals(item1.getId(), mappedItem.getId());
+        assertEquals(item1.getDateCompleted(), mappedItem.getDateCompleted());
+        assertEquals(item1.getStatus(), mappedItem.getStatus());
+        assertEquals(item1.getShoppingListItemId(), mappedItem.getShoppingListItem().getId());
+    }
+
+    @Test
+    void convert_FromHabitAssignDtoToHabitAssign_MinimalDataWithoutShoppingListItems() {
+
+        ZonedDateTime createDateTime = ZonedDateTime.now();
+        HabitDto habitDto = HabitDto.builder().id(6L).complexity(1).build();
+
+        HabitAssignDto habitAssignDto = HabitAssignDto.builder()
+                .id(20L)
+                .duration(21)
+                .habitStreak(0)
+                .createDateTime(createDateTime)
+                .status(HabitAssignStatus.ACTIVE)
+                .workingDays(0)
+                .lastEnrollmentDate(createDateTime)
+                .habit(habitDto)
+                .userShoppingListItems(List.of())
+                .build();
+
+        HabitAssign habitAssign = mapper.convert(habitAssignDto);
+
+        assertNotNull(habitAssign);
+        assertEquals(habitAssignDto.getId(), habitAssign.getId());
+        assertEquals(habitAssignDto.getDuration(), habitAssign.getDuration());
+        assertEquals(habitAssignDto.getHabitStreak(), habitAssign.getHabitStreak());
+        assertEquals(habitAssignDto.getCreateDateTime(), habitAssign.getCreateDate());
+        assertEquals(habitAssignDto.getStatus(), habitAssign.getStatus());
+        assertEquals(habitAssignDto.getWorkingDays(), habitAssign.getWorkingDays());
+        assertEquals(habitAssignDto.getLastEnrollmentDate(), habitAssign.getLastEnrollmentDate());
+
+        assertNotNull(habitAssign.getHabit());
+        assertEquals(habitAssignDto.getHabit().getId(), habitAssign.getHabit().getId());
+        assertEquals(habitAssignDto.getHabit().getComplexity(), habitAssign.getHabit().getComplexity());
+        assertEquals(habitAssignDto.getDuration(), habitAssign.getHabit().getDefaultDuration());
+
+        assertNotNull(habitAssign.getUserShoppingListItems());
+        assertTrue(habitAssign.getUserShoppingListItems().isEmpty());
+    }
+
+    @Test
+    void convert_FromHabitAssignDtoToHabitAssign_NoShoppingListItems() {
+
+        ZonedDateTime createDateTime = ZonedDateTime.now().minusDays(7);
+        ZonedDateTime lastEnrollmentDate = ZonedDateTime.now().minusDays(2);
+        HabitDto habitDto = HabitDto.builder().id(7L).complexity(3).build();
+
+        HabitAssignDto habitAssignDto = HabitAssignDto.builder()
+                .id(25L)
+                .duration(60)
+                .habitStreak(10)
+                .createDateTime(createDateTime)
+                .status(HabitAssignStatus.ACQUIRED)
+                .workingDays(30)
+                .lastEnrollmentDate(lastEnrollmentDate)
+                .habit(habitDto)
+                .userShoppingListItems(Collections.emptyList())
+                .build();
+
+        HabitAssign habitAssign = mapper.convert(habitAssignDto);
+
+        assertNotNull(habitAssign);
+        assertEquals(habitAssignDto.getId(), habitAssign.getId());
+        assertEquals(habitAssignDto.getDuration(), habitAssign.getDuration());
+        assertEquals(habitAssignDto.getHabitStreak(), habitAssign.getHabitStreak());
+        assertEquals(habitAssignDto.getCreateDateTime(), habitAssign.getCreateDate());
+        assertEquals(habitAssignDto.getStatus(), habitAssign.getStatus());
+        assertEquals(habitAssignDto.getWorkingDays(), habitAssign.getWorkingDays());
+        assertEquals(habitAssignDto.getLastEnrollmentDate(), habitAssign.getLastEnrollmentDate());
+
+        assertNotNull(habitAssign.getHabit());
+        assertEquals(habitAssignDto.getHabit().getId(), habitAssign.getHabit().getId());
+        assertEquals(habitAssignDto.getHabit().getComplexity(), habitAssign.getHabit().getComplexity());
+        assertEquals(habitAssignDto.getDuration(), habitAssign.getHabit().getDefaultDuration());
+
+        assertNotNull(habitAssign.getUserShoppingListItems());
+        assertTrue(habitAssign.getUserShoppingListItems().isEmpty());
+    }
+
+    @Test
+    void convert_FromHabitAssignDtoToHabitAssign_EmptyShoppingListItems() {
+
+        ZonedDateTime createDateTime = ZonedDateTime.now().minusDays(1);
+        ZonedDateTime lastEnrollmentDate = ZonedDateTime.now();
+        HabitDto habitDto = HabitDto.builder().id(8L).complexity(4).build();
+
+        HabitAssignDto habitAssignDto = HabitAssignDto.builder()
+                .id(30L)
+                .duration(90)
+                .habitStreak(20)
+                .createDateTime(createDateTime)
+                .status(HabitAssignStatus.ACTIVE)
+                .workingDays(60)
+                .lastEnrollmentDate(lastEnrollmentDate)
+                .habit(habitDto)
+                .userShoppingListItems(List.of())
+                .build();
+
+        HabitAssign habitAssign = mapper.convert(habitAssignDto);
+
+        assertNotNull(habitAssign);
+        assertEquals(habitAssignDto.getId(), habitAssign.getId());
+        assertEquals(habitAssignDto.getDuration(), habitAssign.getDuration());
+        assertEquals(habitAssignDto.getHabitStreak(), habitAssign.getHabitStreak());
+        assertEquals(habitAssignDto.getCreateDateTime(), habitAssign.getCreateDate());
+        assertEquals(habitAssignDto.getStatus(), habitAssign.getStatus());
+        assertEquals(habitAssignDto.getWorkingDays(), habitAssign.getWorkingDays());
+        assertEquals(habitAssignDto.getLastEnrollmentDate(), habitAssign.getLastEnrollmentDate());
+
+        assertNotNull(habitAssign.getHabit());
+        assertEquals(habitAssignDto.getHabit().getId(), habitAssign.getHabit().getId());
+        assertEquals(habitAssignDto.getHabit().getComplexity(), habitAssign.getHabit().getComplexity());
+        assertEquals(habitAssignDto.getDuration(), habitAssign.getHabit().getDefaultDuration());
+
+        assertNotNull(habitAssign.getUserShoppingListItems());
+        assertTrue(habitAssign.getUserShoppingListItems().isEmpty());
+    }
+}

--- a/service/src/test/java/greencity/mapping/HabitAssignMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitAssignMapperTest.java
@@ -41,7 +41,7 @@ public class HabitAssignMapperTest {
         UserShoppingListItemAdvanceDto item2 = UserShoppingListItemAdvanceDto.builder()
                 .id(11L)
                 .dateCompleted(LocalDateTime.now())
-                .status(ShoppingListItemStatus.DONE)
+                .status(ShoppingListItemStatus.INPROGRESS)
                 .shoppingListItemId(101L)
                 .build();
 
@@ -76,13 +76,83 @@ public class HabitAssignMapperTest {
         assertEquals(habitAssignDto.getDuration(), habitAssign.getHabit().getDefaultDuration());
 
         assertNotNull(habitAssign.getUserShoppingListItems());
-        assertEquals(1, habitAssign.getUserShoppingListItems().size());
+        assertEquals(2, habitAssign.getUserShoppingListItems().size());
 
         UserShoppingListItem mappedItem = habitAssign.getUserShoppingListItems().getFirst();
         assertEquals(item1.getId(), mappedItem.getId());
         assertEquals(item1.getDateCompleted(), mappedItem.getDateCompleted());
         assertEquals(item1.getStatus(), mappedItem.getStatus());
         assertEquals(item1.getShoppingListItemId(), mappedItem.getShoppingListItem().getId());
+
+        UserShoppingListItem mappedItem2 = habitAssign.getUserShoppingListItems().get(1);
+        assertEquals(item2.getId(), mappedItem2.getId());
+        assertEquals(item2.getDateCompleted(), mappedItem2.getDateCompleted());
+        assertEquals(item2.getStatus(), mappedItem2.getStatus());
+        assertEquals(item2.getShoppingListItemId(), mappedItem2.getShoppingListItem().getId());
+    }
+
+    @Test
+    void convert_FromHabitAssignDtoToHabitAssign_OnlyInProgressShoppingListItemsAreAdded() {
+
+        ZonedDateTime createDateTime = ZonedDateTime.of(LocalDateTime.now().minusDays(4), ZoneId.of("Europe/Kyiv"));
+        HabitDto habitDto = HabitDto.builder().id(100L).complexity(3).build();
+
+        UserShoppingListItemAdvanceDto itemInProgress1 = UserShoppingListItemAdvanceDto.builder()
+                .id(20L)
+                .dateCompleted(LocalDateTime.now().minusDays(3))
+                .status(ShoppingListItemStatus.INPROGRESS)
+                .shoppingListItemId(300L)
+                .build();
+        UserShoppingListItemAdvanceDto itemDone = UserShoppingListItemAdvanceDto.builder()
+                .id(21L)
+                .dateCompleted(LocalDateTime.now().minusDays(1))
+                .status(ShoppingListItemStatus.DONE)
+                .shoppingListItemId(301L)
+                .build();
+        UserShoppingListItemAdvanceDto itemPlanned = UserShoppingListItemAdvanceDto.builder()
+                .id(22L)
+                .dateCompleted(null)
+                .status(ShoppingListItemStatus.DISABLED)
+                .shoppingListItemId(302L)
+                .build();
+        UserShoppingListItemAdvanceDto itemInProgress2 = UserShoppingListItemAdvanceDto.builder()
+                .id(23L)
+                .dateCompleted(LocalDateTime.now())
+                .status(ShoppingListItemStatus.INPROGRESS)
+                .shoppingListItemId(303L)
+                .build();
+
+        HabitAssignDto habitAssignDto = HabitAssignDto.builder()
+                .id(40L)
+                .duration(60)
+                .habitStreak(15)
+                .createDateTime(createDateTime)
+                .status(HabitAssignStatus.ACTIVE)
+                .workingDays(30)
+                .lastEnrollmentDate(createDateTime)
+                .habit(habitDto)
+                .userShoppingListItems(List.of(itemInProgress1, itemDone, itemPlanned, itemInProgress2))
+                .build();
+
+        HabitAssign habitAssign = mapper.convert(habitAssignDto);
+
+        assertNotNull(habitAssign);
+        assertNotNull(habitAssign.getUserShoppingListItems());
+        assertEquals(2, habitAssign.getUserShoppingListItems().size());
+
+        List<ShoppingListItemStatus> actualStatuses = habitAssign.getUserShoppingListItems().stream()
+                .map(UserShoppingListItem::getStatus)
+                .toList();
+        assertTrue(actualStatuses.contains(ShoppingListItemStatus.INPROGRESS));
+        assertEquals(2, actualStatuses.stream().filter(ShoppingListItemStatus.INPROGRESS::equals).count());
+
+        List<Long> actualItemIds = habitAssign.getUserShoppingListItems().stream()
+                .map(UserShoppingListItem::getId)
+                .toList();
+        assertTrue(actualItemIds.contains(itemInProgress1.getId()));
+        assertTrue(actualItemIds.contains(itemInProgress2.getId()));
+        assertFalse(actualItemIds.contains(itemDone.getId()));
+        assertFalse(actualItemIds.contains(itemPlanned.getId()));
     }
 
     @Test

--- a/service/src/test/java/greencity/mapping/HabitAssignUserDurationDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitAssignUserDurationDtoMapperTest.java
@@ -1,0 +1,99 @@
+package greencity.mapping;
+
+import greencity.dto.habit.HabitAssignUserDurationDto;
+import greencity.entity.Habit;
+import greencity.entity.HabitAssign;
+import greencity.entity.User;
+import greencity.enums.HabitAssignStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+public class HabitAssignUserDurationDtoMapperTest {
+
+    @InjectMocks
+    private HabitAssignUserDurationDtoMapper mapper;
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignUserDurationDto_FullData() {
+
+        User user = User.builder().id(1L).build();
+        Habit habit = Habit.builder().id(2L).build();
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(5L)
+                .user(user)
+                .habit(habit)
+                .status(HabitAssignStatus.INPROGRESS)
+                .workingDays(10)
+                .duration(30)
+                .build();
+
+        HabitAssignUserDurationDto dto = mapper.convert(habitAssign);
+
+        assertNotNull(dto);
+        assertEquals(habitAssign.getId(), dto.getHabitAssignId());
+        assertEquals(habitAssign.getUser().getId(), dto.getUserId());
+        assertEquals(habitAssign.getHabit().getId(), dto.getHabitId());
+        assertEquals(habitAssign.getStatus(), dto.getStatus());
+        assertEquals(habitAssign.getWorkingDays(), dto.getWorkingDays());
+        assertEquals(habitAssign.getDuration(), dto.getDuration());
+    }
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignUserDurationDto_MinimalData() {
+
+        User user = User.builder().id(3L).build();
+        Habit habit = Habit.builder().id(4L).build();
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(6L)
+                .user(user)
+                .habit(habit)
+                .status(HabitAssignStatus.ACTIVE)
+                .workingDays(0)
+                .duration(21)
+                .build();
+
+        HabitAssignUserDurationDto dto = mapper.convert(habitAssign);
+
+        assertNotNull(dto);
+        assertEquals(habitAssign.getId(), dto.getHabitAssignId());
+        assertEquals(habitAssign.getUser().getId(), dto.getUserId());
+        assertEquals(habitAssign.getHabit().getId(), dto.getHabitId());
+        assertEquals(habitAssign.getStatus(), dto.getStatus());
+        assertEquals(habitAssign.getWorkingDays(), dto.getWorkingDays());
+        assertEquals(habitAssign.getDuration(), dto.getDuration());
+    }
+
+    @Test
+    void convert_FromHabitAssignToHabitAssignUserDurationDto_DifferentStatusAndValues() {
+
+        User user = User.builder().id(7L).build();
+        Habit habit = Habit.builder().id(8L).build();
+
+        HabitAssign habitAssign = HabitAssign.builder()
+                .id(9L)
+                .user(user)
+                .habit(habit)
+                .status(HabitAssignStatus.ACQUIRED)
+                .workingDays(30)
+                .duration(90)
+                .build();
+
+        HabitAssignUserDurationDto dto = mapper.convert(habitAssign);
+
+        assertNotNull(dto);
+        assertEquals(habitAssign.getId(), dto.getHabitAssignId());
+        assertEquals(habitAssign.getUser().getId(), dto.getUserId());
+        assertEquals(habitAssign.getHabit().getId(), dto.getHabitId());
+        assertEquals(habitAssign.getStatus(), dto.getStatus());
+        assertEquals(habitAssign.getWorkingDays(), dto.getWorkingDays());
+        assertEquals(habitAssign.getDuration(), dto.getDuration());
+    }
+}

--- a/service/src/test/java/greencity/mapping/HabitDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitDtoMapperTest.java
@@ -1,0 +1,252 @@
+package greencity.mapping;
+
+import greencity.dto.habit.HabitDto;
+import greencity.dto.shoppinglistitem.ShoppingListItemDto;
+import greencity.entity.*;
+import greencity.entity.localization.ShoppingListItemTranslation;
+import greencity.entity.localization.TagTranslation;
+import greencity.enums.ShoppingListItemStatus;
+import greencity.enums.TagType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+public class HabitDtoMapperTest {
+
+    @InjectMocks
+    private HabitDtoMapper mapper;
+
+    @Test
+    void convert_FromHabitTranslationToHabitDto_FullData() {
+
+        Language ukrainian = Language.builder().id(1L).code("uk").build();
+        Language english = Language.builder().id(2L).code("en").build();
+
+        Habit habit = Habit.builder()
+                .id(10L)
+                .image("habit_image.jpg")
+                .defaultDuration(21)
+                .complexity(3)
+                .tags(Set.of(
+                        Tag.builder().id(100L).tagTranslations(List.of(
+                                TagTranslation.builder().id(101L).name("Здоров'я").language(ukrainian).build(),
+                                TagTranslation.builder().id(102L).name("Health").language(english).build()
+                        )).type(TagType.HABIT).build(),
+                        Tag.builder().id(110L).tagTranslations(List.of(
+                                TagTranslation.builder().id(111L).name("Спорт").language(ukrainian).build(),
+                                TagTranslation.builder().id(112L).name("Sport").language(english).build()
+                        )).type(TagType.HABIT).build()
+                ))
+                .shoppingListItems(Set.of(
+                        ShoppingListItem.builder().id(20L).translations(List.of(
+                                ShoppingListItemTranslation.builder().id(21L).content("Купити яблука").language(ukrainian).build(),
+                                ShoppingListItemTranslation.builder().id(22L).content("Buy apples").language(english).build()
+                        )).build(),
+                        ShoppingListItem.builder().id(30L).translations(List.of(
+                                ShoppingListItemTranslation.builder().id(31L).content("Випити води").language(ukrainian).build(),
+                                ShoppingListItemTranslation.builder().id(32L).content("Drink water").language(english).build()
+                        )).build()
+                ))
+                .build();
+
+        HabitTranslation habitTranslationUk = HabitTranslation.builder()
+                .id(5L)
+                .name("Ранкова зарядка")
+                .description("Комплекс вправ для бадьорості")
+                .habitItem("Робити зарядку")
+                .language(ukrainian)
+                .habit(habit)
+                .build();
+
+        HabitDto habitDto = mapper.convert(habitTranslationUk);
+
+        assertNotNull(habitDto);
+        assertEquals(habit.getId(), habitDto.getId());
+        assertEquals(habit.getImage(), habitDto.getImage());
+        assertEquals(habit.getDefaultDuration(), habitDto.getDefaultDuration());
+        assertEquals(habit.getComplexity(), habitDto.getComplexity());
+
+        assertNotNull(habitDto.getHabitTranslation());
+        assertEquals(habitTranslationUk.getName(), habitDto.getHabitTranslation().getName());
+        assertEquals(habitTranslationUk.getDescription(), habitDto.getHabitTranslation().getDescription());
+        assertEquals(habitTranslationUk.getHabitItem(), habitDto.getHabitTranslation().getHabitItem());
+        assertEquals(ukrainian.getCode(), habitDto.getHabitTranslation().getLanguageCode());
+
+        assertNotNull(habitDto.getTags());
+        assertEquals(2, habitDto.getTags().size());
+        assertTrue(habitDto.getTags().containsAll(List.of("Здоров'я", "Спорт")));
+
+        assertNotNull(habitDto.getShoppingListItems());
+        assertEquals(2, habitDto.getShoppingListItems().size());
+
+        Optional<ShoppingListItemDto> appleItem = habitDto.getShoppingListItems().stream()
+                .filter(item -> "Купити яблука".equals(item.getText()))
+                .findFirst();
+        assertTrue(appleItem.isPresent());
+        assertEquals(ShoppingListItemStatus.ACTIVE.toString(), appleItem.get().getStatus());
+        assertEquals(20L, appleItem.get().getId());
+
+        Optional<ShoppingListItemDto> waterItem = habitDto.getShoppingListItems().stream()
+                .filter(item -> "Випити води".equals(item.getText()))
+                .findFirst();
+        assertTrue(waterItem.isPresent());
+        assertEquals(ShoppingListItemStatus.ACTIVE.toString(), waterItem.get().getStatus());
+        assertEquals(30L, waterItem.get().getId());
+    }
+
+    @Test
+    void convert_FromHabitTranslationToHabitDto_NoShoppingListItems() {
+
+        Language english = Language.builder().id(2L).code("en").build();
+        Habit habit = Habit.builder()
+                .id(15L)
+                .image("another_image.png")
+                .defaultDuration(14)
+                .complexity(1)
+                .tags(Set.of(
+                        Tag.builder().id(200L).tagTranslations(List.of(
+                                TagTranslation.builder().id(201L).name("Easy").language(english).build()
+                        )).type(TagType.HABIT).build()
+                ))
+                .shoppingListItems(null)
+                .build();
+
+        HabitTranslation habitTranslationEn = HabitTranslation.builder()
+                .id(8L)
+                .name("Morning exercise")
+                .description("A set of exercises to feel energetic")
+                .habitItem("Do exercise")
+                .language(english)
+                .habit(habit)
+                .build();
+
+        HabitDto habitDto = mapper.convert(habitTranslationEn);
+
+        assertNotNull(habitDto);
+        assertEquals(habit.getId(), habitDto.getId());
+        assertEquals(habit.getImage(), habitDto.getImage());
+        assertEquals(habit.getDefaultDuration(), habitDto.getDefaultDuration());
+        assertEquals(habit.getComplexity(), habitDto.getComplexity());
+
+        assertNotNull(habitDto.getHabitTranslation());
+        assertEquals(habitTranslationEn.getName(), habitDto.getHabitTranslation().getName());
+        assertEquals(habitTranslationEn.getDescription(), habitDto.getHabitTranslation().getDescription());
+        assertEquals(habitTranslationEn.getHabitItem(), habitDto.getHabitTranslation().getHabitItem());
+        assertEquals(english.getCode(), habitDto.getHabitTranslation().getLanguageCode());
+
+        assertNotNull(habitDto.getTags());
+        assertEquals(1, habitDto.getTags().size());
+        assertTrue(habitDto.getTags().contains("Easy"));
+
+        assertNotNull(habitDto.getShoppingListItems());
+        assertTrue(habitDto.getShoppingListItems().isEmpty());
+    }
+
+    @Test
+    void convert_FromHabitTranslationToHabitDto_NoTags() {
+
+        Language ukrainian = Language.builder().id(1L).code("uk").build();
+        Habit habit = Habit.builder()
+                .id(20L)
+                .image("no_tags.jpg")
+                .defaultDuration(7)
+                .complexity(5)
+                .tags(Set.of())
+                .shoppingListItems(Set.of(
+                        ShoppingListItem.builder().id(40L).translations(List.of(
+                                ShoppingListItemTranslation.builder().id(41L).content("Прибрати кімнату").language(ukrainian).build()
+                        )).build()
+                ))
+                .build();
+
+        HabitTranslation habitTranslationUk = HabitTranslation.builder()
+                .id(12L)
+                .name("Прибирання")
+                .description("Регулярне прибирання оселі")
+                .habitItem("Прибирати")
+                .language(ukrainian)
+                .habit(habit)
+                .build();
+
+        HabitDto habitDto = mapper.convert(habitTranslationUk);
+
+        assertNotNull(habitDto);
+        assertEquals(habit.getId(), habitDto.getId());
+        assertEquals(habit.getImage(), habitDto.getImage());
+        assertEquals(habit.getDefaultDuration(), habitDto.getDefaultDuration());
+        assertEquals(habit.getComplexity(), habitDto.getComplexity());
+
+        assertNotNull(habitDto.getHabitTranslation());
+        assertEquals(habitTranslationUk.getName(), habitDto.getHabitTranslation().getName());
+        assertEquals(habitTranslationUk.getDescription(), habitDto.getHabitTranslation().getDescription());
+        assertEquals(habitTranslationUk.getHabitItem(), habitDto.getHabitTranslation().getHabitItem());
+        assertEquals(ukrainian.getCode(), habitDto.getHabitTranslation().getLanguageCode());
+
+        assertNotNull(habitDto.getTags());
+        assertTrue(habitDto.getTags().isEmpty());
+
+        assertNotNull(habitDto.getShoppingListItems());
+        assertEquals(1, habitDto.getShoppingListItems().size());
+        assertEquals("Прибрати кімнату", habitDto.getShoppingListItems().getFirst().getText());
+        assertEquals(ShoppingListItemStatus.ACTIVE.toString(), habitDto.getShoppingListItems().getFirst().getStatus());
+    }
+
+    @Test
+    void convert_FromHabitTranslationToHabitDto_ShoppingListItemWithoutTranslationForCurrentLanguage() {
+
+        Language ukrainian = Language.builder().id(1L).code("uk").build();
+        Language english = Language.builder().id(2L).code("en").build();
+        Habit habit = Habit.builder()
+                .id(25L)
+                .image("no_translation.jpg")
+                .defaultDuration(5)
+                .complexity(2)
+                .tags(Set.of())
+                .shoppingListItems(Set.of(
+                        ShoppingListItem.builder().id(50L).translations(List.of(
+                                ShoppingListItemTranslation.builder().id(51L).content("Buy milk").language(english).build()
+                        )).build()
+                ))
+                .build();
+
+        HabitTranslation habitTranslationUk = HabitTranslation.builder()
+                .id(15L)
+                .name("Пити молоко")
+                .description("Регулярне вживання молока")
+                .habitItem("Випивати склянку молока")
+                .language(ukrainian)
+                .habit(habit)
+                .build();
+
+        HabitDto habitDto = mapper.convert(habitTranslationUk);
+
+        assertNotNull(habitDto);
+        assertEquals(habit.getId(), habitDto.getId());
+        assertEquals(habit.getImage(), habitDto.getImage());
+        assertEquals(habit.getDefaultDuration(), habitDto.getDefaultDuration());
+        assertEquals(habit.getComplexity(), habitDto.getComplexity());
+
+        assertNotNull(habitDto.getHabitTranslation());
+        assertEquals(habitTranslationUk.getName(), habitDto.getHabitTranslation().getName());
+        assertEquals(habitTranslationUk.getDescription(), habitDto.getHabitTranslation().getDescription());
+        assertEquals(habitTranslationUk.getHabitItem(), habitDto.getHabitTranslation().getHabitItem());
+        assertEquals(ukrainian.getCode(), habitDto.getHabitTranslation().getLanguageCode());
+
+        assertNotNull(habitDto.getTags());
+        assertTrue(habitDto.getTags().isEmpty());
+
+        assertNotNull(habitDto.getShoppingListItems());
+        assertEquals(1, habitDto.getShoppingListItems().size());
+        assertNull(habitDto.getShoppingListItems().getFirst().getText());
+        assertEquals(50L, habitDto.getShoppingListItems().getFirst().getId());
+        assertEquals(ShoppingListItemStatus.ACTIVE.toString(), habitDto.getShoppingListItems().getFirst().getStatus());
+    }
+}

--- a/service/src/test/java/greencity/mapping/HabitFactDtoResponseMapperTest.java
+++ b/service/src/test/java/greencity/mapping/HabitFactDtoResponseMapperTest.java
@@ -1,0 +1,197 @@
+package greencity.mapping;
+
+import greencity.dto.habit.HabitVO;
+import greencity.dto.habitfact.HabitFactDtoResponse;
+import greencity.dto.habitfact.HabitFactTranslationDto;
+import greencity.dto.habitfact.HabitFactTranslationVO;
+import greencity.dto.habitfact.HabitFactVO;
+import greencity.dto.language.LanguageVO;
+import greencity.enums.FactOfDayStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(MockitoExtension.class)
+public class HabitFactDtoResponseMapperTest {
+
+    @InjectMocks
+    private HabitFactDtoResponseMapper mapper;
+
+    @Test
+    void convert_FromHabitFactVOToHabitFactDtoResponse_FullData() {
+
+        LanguageVO ukrainian = LanguageVO.builder().id(1L).code("uk").build();
+        LanguageVO english = LanguageVO.builder().id(2L).code("en").build();
+        HabitVO habitVO = HabitVO.builder().id(10L).image("running.jpg").complexity(2).build();
+
+        HabitFactTranslationVO translationUkVO = HabitFactTranslationVO.builder()
+                .id(100L)
+                .content("Біг корисний для здоров'я.")
+                .factOfDayStatus(FactOfDayStatus.CURRENT)
+                .language(ukrainian)
+                .build();
+
+        HabitFactTranslationVO translationEnVO = HabitFactTranslationVO.builder()
+                .id(101L)
+                .content("Running is good for health.")
+                .factOfDayStatus(FactOfDayStatus.POTENTIAL)
+                .language(english)
+                .build();
+
+        HabitFactVO habitFactVO = HabitFactVO.builder()
+                .id(50L)
+                .habit(habitVO)
+                .translations(List.of(translationUkVO, translationEnVO))
+                .build();
+
+        HabitFactDtoResponse responseDto = mapper.convert(habitFactVO);
+
+        assertNotNull(responseDto);
+        assertEquals(habitFactVO.getId(), responseDto.getId());
+        assertEquals(habitFactVO.getHabit(), responseDto.getHabit());
+        assertNotNull(responseDto.getTranslations());
+        assertEquals(habitFactVO.getTranslations().size(), responseDto.getTranslations().size());
+
+        List<HabitFactTranslationDto> translationsDto = responseDto.getTranslations();
+
+        HabitFactTranslationDto dtoUk = translationsDto.stream()
+                .filter(dto -> dto.getLanguage().getCode().equals("uk"))
+                .findFirst().orElse(null);
+        assertNotNull(dtoUk);
+        assertEquals(translationUkVO.getId(), dtoUk.getId());
+        assertEquals(translationUkVO.getContent(), dtoUk.getContent());
+        assertEquals(FactOfDayStatus.CURRENT, dtoUk.getFactOfDayStatus());
+        assertEquals(translationUkVO.getLanguage().getId(), dtoUk.getLanguage().getId());
+        assertEquals(translationUkVO.getLanguage().getCode(), dtoUk.getLanguage().getCode());
+        assertEquals(habitVO, responseDto.getHabit()); // Verify HabitVO in response
+
+        HabitFactTranslationDto dtoEn = translationsDto.stream()
+                .filter(dto -> dto.getLanguage().getCode().equals("en"))
+                .findFirst().orElse(null);
+        assertNotNull(dtoEn);
+        assertEquals(translationEnVO.getId(), dtoEn.getId());
+        assertEquals(translationEnVO.getContent(), dtoEn.getContent());
+        assertEquals(FactOfDayStatus.POTENTIAL, dtoEn.getFactOfDayStatus());
+        assertEquals(translationEnVO.getLanguage().getId(), dtoEn.getLanguage().getId());
+        assertEquals(translationEnVO.getLanguage().getCode(), dtoEn.getLanguage().getCode());
+    }
+
+    @Test
+    void convert_FromHabitFactVOToHabitFactDtoResponse_NoTranslations() {
+
+        HabitVO habitVO = HabitVO.builder().id(12L).image("walking.jpg").complexity(3).build();
+
+        HabitFactVO habitFactVO = HabitFactVO.builder()
+                .id(52L)
+                .habit(habitVO)
+                .translations(List.of())
+                .build();
+
+        HabitFactDtoResponse responseDto = mapper.convert(habitFactVO);
+
+        assertNotNull(responseDto);
+        assertEquals(habitFactVO.getId(), responseDto.getId());
+        assertEquals(habitFactVO.getHabit(), responseDto.getHabit());
+        assertNotNull(responseDto.getTranslations());
+        assertEquals(0, responseDto.getTranslations().size());
+        assertEquals(habitVO, responseDto.getHabit());
+    }
+
+    @Test
+    void convert_FromHabitFactVOToHabitFactDtoResponse_DifferentFactOfDayStatus() {
+
+        LanguageVO english = LanguageVO.builder().id(2L).code("en").build();
+        HabitVO habitVO = HabitVO.builder().id(13L).image("sleeping.jpg").complexity(2).build();
+
+        HabitFactTranslationVO translationEnVO = HabitFactTranslationVO.builder()
+                .id(103L)
+                .content("Sufficient sleep is crucial for well-being.")
+                .factOfDayStatus(FactOfDayStatus.POTENTIAL)
+                .language(english)
+                .build();
+
+        HabitFactVO habitFactVO = HabitFactVO.builder()
+                .id(53L)
+                .habit(habitVO)
+                .translations(List.of(translationEnVO))
+                .build();
+
+        HabitFactDtoResponse responseDto = mapper.convert(habitFactVO);
+
+        assertNotNull(responseDto);
+        assertEquals(habitFactVO.getId(), responseDto.getId());
+        assertEquals(habitFactVO.getHabit(), responseDto.getHabit());
+        assertNotNull(responseDto.getTranslations());
+        assertEquals(1, responseDto.getTranslations().size());
+
+        HabitFactTranslationDto dtoEn = responseDto.getTranslations().get(0);
+        assertEquals(translationEnVO.getId(), dtoEn.getId());
+        assertEquals(translationEnVO.getContent(), dtoEn.getContent());
+        assertEquals(FactOfDayStatus.POTENTIAL, dtoEn.getFactOfDayStatus());
+        assertEquals(translationEnVO.getLanguage().getId(), dtoEn.getLanguage().getId());
+        assertEquals(translationEnVO.getLanguage().getCode(), dtoEn.getLanguage().getCode());
+        assertEquals(habitVO, responseDto.getHabit());
+    }
+
+    @Test
+    void convert_FromHabitFactVOToHabitFactDtoResponse_VariousFactOfDayStatuses() {
+
+        LanguageVO ukrainian = LanguageVO.builder().id(1L).code("uk").build();
+        LanguageVO english = LanguageVO.builder().id(2L).code("en").build();
+        HabitVO habitVO = HabitVO.builder().id(14L).image("hydration.jpg").complexity(1).build();
+
+        HabitFactTranslationVO translationUkCurrentVO = HabitFactTranslationVO.builder()
+                .id(104L)
+                .content("Пийте достатньо води сьогодні.")
+                .factOfDayStatus(FactOfDayStatus.CURRENT)
+                .language(ukrainian)
+                .build();
+
+        HabitFactTranslationVO translationEnPotentialVO = HabitFactTranslationVO.builder()
+                .id(105L)
+                .content("Consider drinking more water.")
+                .factOfDayStatus(FactOfDayStatus.POTENTIAL)
+                .language(english)
+                .build();
+
+        HabitFactTranslationVO translationUkUsedVO = HabitFactTranslationVO.builder()
+                .id(106L)
+                .content("Ви вже випили свою норму води.")
+                .factOfDayStatus(FactOfDayStatus.USED)
+                .language(ukrainian)
+                .build();
+
+        HabitFactVO habitFactVO = HabitFactVO.builder()
+                .id(54L)
+                .habit(habitVO)
+                .translations(List.of(translationUkCurrentVO, translationEnPotentialVO, translationUkUsedVO))
+                .build();
+
+        HabitFactDtoResponse responseDto = mapper.convert(habitFactVO);
+
+        assertNotNull(responseDto);
+        assertEquals(habitFactVO.getId(), responseDto.getId());
+        assertEquals(habitFactVO.getHabit(), responseDto.getHabit());
+        assertNotNull(responseDto.getTranslations());
+        assertEquals(3, responseDto.getTranslations().size());
+        assertEquals(habitVO, responseDto.getHabit());
+
+        responseDto.getTranslations().forEach(dto -> {
+            if (dto.getLanguage().getCode().equals("uk")) {
+                if (dto.getContent().contains("сьогодні")) {
+                    assertEquals(FactOfDayStatus.CURRENT, dto.getFactOfDayStatus());
+                } else if (dto.getContent().contains("випили")) {
+                    assertEquals(FactOfDayStatus.USED, dto.getFactOfDayStatus());
+                }
+            } else if (dto.getLanguage().getCode().equals("en")) {
+                assertEquals(FactOfDayStatus.POTENTIAL, dto.getFactOfDayStatus());
+            }
+        });
+    }
+}


### PR DESCRIPTION
Added unit tests for first part HabitMappers in the greencity.mapping package. Covered mappings between entities, DTOs, and VOs. Verified correct data transformation and handling of edge cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a robust suite of unit tests to validate and ensure accurate data mappings between core objects under various scenarios, including full data, minimal data, and edge cases.
	- These tests enhance overall application stability and reliability by rigorously checking that data conversions perform as expected.
	- Introduced new test classes for `HabitAssignDtoMapper`, `HabitAssignManagementDtoMapper`, `HabitAssignMapper`, `HabitAssignUserDurationDtoMapper`, `HabitDtoMapper`, and `HabitFactDtoResponseMapper` to cover various mapping scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->