### PR TITLE
test/15-add unit tests for Custom mappers

### DIFF
--- a/service/src/test/java/greencity/mapping/CustomHabitMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CustomHabitMapperTest.java
@@ -1,0 +1,65 @@
+package greencity.mapping;
+
+import greencity.dto.habit.AddCustomHabitDtoRequest;
+import greencity.entity.Habit;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CustomHabitMapperTest {
+    private final CustomHabitMapper customHabitMapper = new CustomHabitMapper();
+
+    @Test
+    void convert_validHabitDtoRequest_returnsHabit() {
+        AddCustomHabitDtoRequest addCustomHabitDtoRequest = AddCustomHabitDtoRequest.builder()
+                .image("image.png")
+                .complexity(10)
+                .defaultDuration(25)
+                .build();
+
+        Habit expected = Habit.builder()
+                .image(addCustomHabitDtoRequest.getImage())
+                .complexity(addCustomHabitDtoRequest.getComplexity())
+                .defaultDuration(addCustomHabitDtoRequest.getDefaultDuration())
+                .isCustomHabit(true)
+                .build();
+
+        Habit actual = customHabitMapper.convert(addCustomHabitDtoRequest);
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void convert_emptyAddCustomHabitDtoRequest_returnsEmptyHabit() {
+        AddCustomHabitDtoRequest emptyAddCustomHabitDtoRequest = new AddCustomHabitDtoRequest();
+
+        assertEquals(new Habit().setIsCustomHabit(true), customHabitMapper.convert(emptyAddCustomHabitDtoRequest));
+    }
+
+    @Test
+    void convert_nullAddCustomHabitDtoRequest_throwsNullPointerException() {
+        AddCustomHabitDtoRequest addCustomHabitDtoRequest = null;
+
+        assertThrows(NullPointerException.class, () -> customHabitMapper.convert(addCustomHabitDtoRequest));
+    }
+
+    @Test
+    void convert_addCustomHabitDtoRequestWithOnlyImageField_returnsHabit() {
+        AddCustomHabitDtoRequest addCustomHabitDtoRequest = AddCustomHabitDtoRequest.builder()
+                .image("image.png")
+                .complexity(null)
+                .defaultDuration(null)
+                .build();
+
+        Habit expected = Habit.builder()
+                .image("image.png")
+                .isCustomHabit(true)
+                .build();
+
+        assertEquals(expected, customHabitMapper.convert(addCustomHabitDtoRequest));
+        assertThat(addCustomHabitDtoRequest.getComplexity()).isNull();
+        assertThat(addCustomHabitDtoRequest.getDefaultDuration()).isNull();
+    }
+}

--- a/service/src/test/java/greencity/mapping/CustomShoppingListMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CustomShoppingListMapperTest.java
@@ -56,7 +56,7 @@ public class CustomShoppingListMapperTest {
     }
 
     @Test
-    void mapAllToList_nullCustomShoppingListItemResponseDto_returnsEmptyList() {
+    void mapAllToList_nullCustomShoppingListItemResponseDto_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> mapper.mapAllToList(null));
     }
 }

--- a/service/src/test/java/greencity/mapping/CustomShoppingListMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CustomShoppingListMapperTest.java
@@ -1,0 +1,62 @@
+package greencity.mapping;
+
+import greencity.dto.shoppinglistitem.CustomShoppingListItemResponseDto;
+import greencity.entity.CustomShoppingListItem;
+import greencity.enums.ShoppingListItemStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static greencity.ModelUtils.getCustomShoppingListItem;
+import static greencity.ModelUtils.getCustomShoppingListItemResponseDto;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CustomShoppingListMapperTest {
+    private final CustomShoppingListMapper mapper = new CustomShoppingListMapper();
+    private final CustomShoppingListItemResponseDto customShoppingListItemResponseDto = getCustomShoppingListItemResponseDto();
+    private final CustomShoppingListItem customShoppingListItem = getCustomShoppingListItem();
+
+    @Test
+    void convert_validCustomShoppingListItemResponseDto_returnsCustomShoppingListItem() {
+
+        assertEquals(customShoppingListItem, mapper.convert(customShoppingListItemResponseDto));
+    }
+
+    @Test
+    void convert_nullCustomShoppingListItemResponseDto_throwsNullPointerException() {
+        CustomShoppingListItemResponseDto nullCustomShoppingListItemResponseDto = null;
+        assertThrows(NullPointerException.class, () -> mapper.convert(nullCustomShoppingListItemResponseDto));
+    }
+
+    @Test
+    void convert_emptyCustomShoppingListItemResponseDto_returnsEmptyCustomShoppingListItem() {
+        CustomShoppingListItemResponseDto emptyCustomShoppingListItemResponseDto = new CustomShoppingListItemResponseDto();
+        assertEquals(new CustomShoppingListItem().setStatus(null), mapper.convert(emptyCustomShoppingListItemResponseDto));
+    }
+
+    @Test
+    void mapAllToList_validCustomShoppingListItemResponseDto_returnsCustomShoppingListItem() {
+        List<CustomShoppingListItemResponseDto> customShoppingListItemResponseDtos = Arrays.asList(
+                new CustomShoppingListItemResponseDto()
+                        .setId(5L)
+                        .setStatus(ShoppingListItemStatus.ACTIVE)
+                        .setText("List item №1"),
+                customShoppingListItemResponseDto
+        );
+
+        List<CustomShoppingListItem> expected = Arrays.asList(
+                new CustomShoppingListItem()
+                        .setId(5L)
+                        .setText("List item №1"),
+                customShoppingListItem
+        );
+        assertEquals(expected, mapper.mapAllToList(customShoppingListItemResponseDtos));
+    }
+
+    @Test
+    void mapAllToList_nullCustomShoppingListItemResponseDto_returnsEmptyList() {
+        assertThrows(NullPointerException.class, () -> mapper.mapAllToList(null));
+    }
+}

--- a/service/src/test/java/greencity/mapping/CustomShoppingListResponseDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/CustomShoppingListResponseDtoMapperTest.java
@@ -1,0 +1,60 @@
+package greencity.mapping;
+
+import greencity.dto.shoppinglistitem.CustomShoppingListItemResponseDto;
+import greencity.entity.CustomShoppingListItem;
+import greencity.enums.ShoppingListItemStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static greencity.ModelUtils.getCustomShoppingListItem;
+import static greencity.ModelUtils.getCustomShoppingListItemResponseDto;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CustomShoppingListResponseDtoMapperTest {
+    private final CustomShoppingListResponseDtoMapper mapper = new CustomShoppingListResponseDtoMapper();
+    private final CustomShoppingListItem customShoppingListItem = getCustomShoppingListItem();
+    private final CustomShoppingListItemResponseDto customShoppingListItemResponseDto = getCustomShoppingListItemResponseDto();
+
+    @Test
+    void convert_validCustomShoppingListItem_returnsCustomShoppingListItemResponseDto() {
+        assertEquals(customShoppingListItemResponseDto, mapper.convert(customShoppingListItem));
+    }
+
+    @Test
+    void convert_nullCustomShoppingListItem_throwsNullPointerException() {
+        CustomShoppingListItem nullCustomShoppingListItem = null;
+        assertThrows(NullPointerException.class, () -> mapper.convert(nullCustomShoppingListItem));
+    }
+
+    @Test
+    void convert_emptyCustomShoppingListItem_returnsEmptyCustomShoppingListItemResponseDto() {
+        CustomShoppingListItem emptyCustomShoppingListItem = new CustomShoppingListItem();
+        assertEquals(new CustomShoppingListItemResponseDto().setStatus(ShoppingListItemStatus.ACTIVE), mapper.convert(emptyCustomShoppingListItem));
+    }
+
+    @Test
+    void mapAllToList_validCustomShoppingListItem_returnsListOfCustomShoppingListItemResponseDto() {
+        List<CustomShoppingListItem> customShoppingListItemList = Arrays.asList(
+                new CustomShoppingListItem()
+                        .setId(5L)
+                        .setText("List item №1"),
+                customShoppingListItem
+        );
+        List<CustomShoppingListItemResponseDto> expected = Arrays.asList(
+                new CustomShoppingListItemResponseDto()
+                        .setId(5L)
+                        .setStatus(ShoppingListItemStatus.ACTIVE)
+                        .setText("List item №1"),
+                customShoppingListItemResponseDto
+        );
+        assertEquals(expected, mapper.mapAllToList(customShoppingListItemList));
+    }
+
+    @Test
+    void mapAllToList_nullCustomShoppingListItem_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> mapper.mapAllToList(null));
+    }
+}


### PR DESCRIPTION
**Package:**  
`service/src/main/java/greencity/mapping`

###  Description

Write **unit tests** for all mapper classes in the `greencity.mapping` package.  
These classes convert between entity objects, DTOs, and VO (value objects), and are essential for ensuring proper separation between data models and API representations.

### Classes to Cover
- `CustomHabitMapper`  
- `CustomShoppingListMapper`  
- `CustomShoppingListResponseDtoMapper`  

###  Test Scenarios

For each mapper:
- [ ] Convert from entity to DTO
- [ ] Convert from DTO to entity (if applicable)
- [ ] Handle null or empty input
- [ ] Validate that all fields are properly mapped
- [ ] Assert object equality using `assertEquals` or deep comparison libraries


###  Acceptance Criteria

- [ ] All tests pass successfully
- [ ] Tests follow Arrange-Act-Assert structure
- [ ] Mappers that use other dependencies (e.g., `ModelMapper`) are mocked or configured
- [ ] Corner cases like `null` or partially filled objects are tested
- [ ] **100% line and branch test coverage**
- [ ] Code is clean and adheres to project standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added new automated tests to validate data conversion processes for managing custom habits and shopping lists.
	- Enhanced system reliability by confirming proper handling of valid, empty, and null input scenarios across multiple components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->