### PR TITLE
feat: Add Kafka producer for notifications system

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,6 +37,10 @@
             <version>2.3.0</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>greencity</groupId>
             <artifactId>service-api</artifactId>
             <version>${project.version}</version>

--- a/core/src/main/java/greencity/annotations/ValidSource.java
+++ b/core/src/main/java/greencity/annotations/ValidSource.java
@@ -1,0 +1,21 @@
+package greencity.annotations;
+
+import static greencity.constant.ErrorMessage.INVALID_SOURCE;
+import greencity.validator.SourceValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = SourceValidator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface ValidSource {
+    String message() default INVALID_SOURCE;
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/core/src/main/java/greencity/config/KafkaConfig.java
+++ b/core/src/main/java/greencity/config/KafkaConfig.java
@@ -1,0 +1,34 @@
+package greencity.config;
+
+import greencity.dto.notification.NotificationEvent;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaConfig {
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, NotificationEvent> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, NotificationEvent> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/core/src/main/java/greencity/config/SecurityConfig.java
+++ b/core/src/main/java/greencity/config/SecurityConfig.java
@@ -102,7 +102,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 .requestMatchers("/", "/management/", "/management/login").permitAll()
                 .requestMatchers("/v2/api-docs/**", "/v3/api-docs/**", "/swagger.json",
-                    "/swagger-ui.html")
+                    "/swagger-ui.html", "/error")
                 .permitAll()
                 .requestMatchers("/swagger-resources/**", "/webjars/**", "/swagger-ui/**").permitAll()
                 .requestMatchers("/management/**",
@@ -195,7 +195,8 @@ public class SecurityConfig {
                     "/habit/assign/{habitAssignId}",
                     "/habit/tags/search",
                     "/habit/search",
-                    "/habit/{habitId}/friends/profile-pictures")
+                    "/habit/{habitId}/friends/profile-pictures",
+                    "/notifications/user")
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.POST,
                     "/category",
@@ -217,7 +218,8 @@ public class SecurityConfig {
                     USER_SHOPPING_LIST,
                     "/user/{userId}/habit",
                     "/habit/custom",
-                    "/custom/shopping-list-items/{userId}/{habitId}/custom-shopping-list-items")
+                    "/custom/shopping-list-items/{userId}/{habitId}/custom-shopping-list-items",
+                    "/notifications/")
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.PUT,
                     "/habit/statistic/{id}",
@@ -251,7 +253,8 @@ public class SecurityConfig {
                     "/favorite_place/{placeId}",
                     "/social-networks",
                     USER_CUSTOM_SHOPPING_LIST_ITEMS,
-                    USER_SHOPPING_LIST + "/user-shopping-list-items")
+                    USER_SHOPPING_LIST + "/user-shopping-list-items",
+                    "/notifications")
                 .hasAnyRole(USER, ADMIN, MODERATOR, UBS_EMPLOYEE)
                 .requestMatchers(HttpMethod.GET,
                     "/newsSubscriber",

--- a/core/src/main/java/greencity/controller/EcoNewsController.java
+++ b/core/src/main/java/greencity/controller/EcoNewsController.java
@@ -75,8 +75,8 @@ public class EcoNewsController {
     public ResponseEntity<EcoNewsGenericDto> save(
         @Parameter(description = SwaggerExampleModel.ADD_ECO_NEWS_REQUEST,
             required = true) @RequestPart @ValidEcoNewsDtoRequest AddEcoNewsDtoRequest addEcoNewsDtoRequest,
-        @Parameter(description = "Image of eco news") @ImageValidation
-        @RequestPart(required = false) MultipartFile image,
+        @Parameter(description = "Image of eco news") @ImageValidation @RequestPart(
+            required = false) MultipartFile image,
         @Parameter(hidden = true) Principal principal) {
         return ResponseEntity.status(HttpStatus.CREATED).body(
             ecoNewsService.saveEcoNews(addEcoNewsDtoRequest, image, principal.getName()));

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -1,0 +1,42 @@
+package greencity.controller;
+
+import greencity.constant.HttpStatuses;
+import greencity.dto.notification.NotificationEvent;
+import greencity.service.NotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@Validated
+@AllArgsConstructor
+@RestController
+@RequestMapping("/notifications")
+public class NotificationController {
+    private final NotificationService notificationService;
+
+    @Operation(summary = "Add new notification.")
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = HttpStatuses.CREATED,
+            content = @Content(schema = @Schema(implementation = NotificationEvent.class))),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+    })
+    @PostMapping("/")
+    public ResponseEntity<NotificationEvent> post(@RequestBody NotificationEvent notificationEvent) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(notificationService.saveNotification(notificationEvent));
+    }
+
+    @GetMapping("/")
+    public ResponseEntity<List<NotificationEvent>> get() {
+        return ResponseEntity.status(HttpStatus.OK).body(notificationService.findAllNotifications());
+    }
+}

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -64,4 +64,17 @@ public class NotificationController {
         return ResponseEntity.status(HttpStatus.OK)
             .body(notificationService.findUserNotifications(userVO.getId(), filter));
     }
+
+    @Operation(summary = "Delete notification by id.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+    })
+    @DeleteMapping
+    public ResponseEntity<Object> delete(@Parameter(hidden = true) @CurrentUser UserVO userVO,
+                                         @RequestParam Long id) {
+        notificationService.deleteNotification(id, userVO.getId());
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
 }

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -1,9 +1,13 @@
 package greencity.controller;
 
+import greencity.annotations.CurrentUser;
 import greencity.constant.HttpStatuses;
+import greencity.dto.notification.NotificationDtoRequest;
 import greencity.dto.notification.NotificationEvent;
+import greencity.dto.user.UserVO;
 import greencity.service.NotificationService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -35,8 +39,26 @@ public class NotificationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(notificationService.saveNotification(notificationEvent));
     }
 
+    @Operation(summary = "Get all notifications.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "410", description = HttpStatuses.UNAUTHORIZED),
+    })
     @GetMapping("/")
     public ResponseEntity<List<NotificationEvent>> get() {
         return ResponseEntity.status(HttpStatus.OK).body(notificationService.findAllNotifications());
+    }
+
+    @Operation(summary = "Get all notifications.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
+        @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
+        @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+    })
+    @GetMapping("/user")
+    public ResponseEntity<List<NotificationDtoRequest>> getNotificationsForUser(
+        @Parameter(hidden = true) @CurrentUser UserVO userVO) {
+        return ResponseEntity.status(HttpStatus.OK).body(notificationService.findUserNotifications(userVO.getId()));
     }
 }

--- a/core/src/main/java/greencity/controller/NotificationController.java
+++ b/core/src/main/java/greencity/controller/NotificationController.java
@@ -1,6 +1,7 @@
 package greencity.controller;
 
 import greencity.annotations.CurrentUser;
+import greencity.annotations.ValidSource;
 import greencity.constant.HttpStatuses;
 import greencity.dto.notification.NotificationDtoRequest;
 import greencity.dto.notification.NotificationEvent;
@@ -50,7 +51,7 @@ public class NotificationController {
         return ResponseEntity.status(HttpStatus.OK).body(notificationService.findAllNotifications());
     }
 
-    @Operation(summary = "Get all notifications.")
+    @Operation(summary = "Get all notifications for specific user.")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
@@ -58,7 +59,9 @@ public class NotificationController {
     })
     @GetMapping("/user")
     public ResponseEntity<List<NotificationDtoRequest>> getNotificationsForUser(
-        @Parameter(hidden = true) @CurrentUser UserVO userVO) {
-        return ResponseEntity.status(HttpStatus.OK).body(notificationService.findUserNotifications(userVO.getId()));
+        @Parameter(hidden = true) @CurrentUser UserVO userVO,
+        @RequestParam(defaultValue = "ALL") @ValidSource String filter) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(notificationService.findUserNotifications(userVO.getId(), filter));
     }
 }

--- a/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
+++ b/core/src/main/java/greencity/exception/handler/CustomExceptionHandler.java
@@ -625,4 +625,11 @@ public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
             .status(HttpStatus.FORBIDDEN)
             .body(ex.getMessage());
     }
+
+    @ExceptionHandler(NotificationNotFound.class)
+    public ResponseEntity<Object> handleNotificationNotFound(NotificationNotFound ex) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body(ex.getMessage());
+    }
 }

--- a/core/src/main/java/greencity/validator/SourceValidator.java
+++ b/core/src/main/java/greencity/validator/SourceValidator.java
@@ -1,0 +1,23 @@
+package greencity.validator;
+
+import greencity.annotations.ValidSource;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.Set;
+
+public class SourceValidator implements ConstraintValidator<ValidSource, String> {
+    private static final Set<String> VALID_SOURCES = Set.of("ALL", "GREENCITY", "PICKUP");
+
+    @Override
+    public void initialize(ValidSource constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(String s, ConstraintValidatorContext constraintValidatorContext) {
+        if (s == null) {
+            return true;
+        }
+        return VALID_SOURCES.contains(s.toUpperCase());
+    }
+}

--- a/dao/src/main/java/greencity/entity/Notification.java
+++ b/dao/src/main/java/greencity/entity/Notification.java
@@ -37,6 +37,9 @@ public class Notification {
     @Enumerated(EnumType.STRING)
     @Column(name = "status")
     private NotificationStatus status = NotificationStatus.UNREAD;
+    
+    @Column(name = "timestamp_deletion")
+    private LocalDateTime timestampDeletion;
 
     @PrePersist
     public void prePersist() {

--- a/dao/src/main/java/greencity/entity/Notification.java
+++ b/dao/src/main/java/greencity/entity/Notification.java
@@ -9,6 +9,7 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Entity
+@Builder
 @Table(name = "notification")
 public class Notification {
     @Id
@@ -27,4 +28,8 @@ public class Notification {
 
     @Column(name = "timestamp", nullable = false)
     private LocalDateTime timestamp;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "payload_id", referencedColumnName = "id")
+    private NotificationPayload payload;
 }

--- a/dao/src/main/java/greencity/entity/Notification.java
+++ b/dao/src/main/java/greencity/entity/Notification.java
@@ -1,5 +1,6 @@
 package greencity.entity;
 
+import greencity.enums.NotificationStatus;
 import greencity.enums.NotificationType;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -32,4 +33,15 @@ public class Notification {
     @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "payload_id", referencedColumnName = "id")
     private NotificationPayload payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private NotificationStatus status = NotificationStatus.UNREAD;
+
+    @PrePersist
+    public void prePersist() {
+        if (status == null) {
+            status = NotificationStatus.UNREAD;
+        }
+    }
 }

--- a/dao/src/main/java/greencity/entity/Notification.java
+++ b/dao/src/main/java/greencity/entity/Notification.java
@@ -1,0 +1,30 @@
+package greencity.entity;
+
+import greencity.enums.NotificationType;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "notification")
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "event_type")
+    private NotificationType eventType;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "source", nullable = false)
+    private String source;
+
+    @Column(name = "timestamp", nullable = false)
+    private LocalDateTime timestamp;
+}

--- a/dao/src/main/java/greencity/entity/NotificationPayload.java
+++ b/dao/src/main/java/greencity/entity/NotificationPayload.java
@@ -1,0 +1,31 @@
+package greencity.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+@Table(name = "notification_payload")
+public class NotificationPayload {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "actor_id")
+    private Long actorId;
+
+    @Column(name = "actor_name")
+    private String actorName;
+
+    @Column(name = "article_id")
+    private Long articleId;
+
+    @Column(name = "article_title")
+    private String articleTitle;
+
+    @Column(name = "object_type")
+    private String objectType;
+}

--- a/dao/src/main/java/greencity/enums/NotificationStatus.java
+++ b/dao/src/main/java/greencity/enums/NotificationStatus.java
@@ -1,0 +1,5 @@
+package greencity.enums;
+
+public enum NotificationStatus {
+    READ, UNREAD
+}

--- a/dao/src/main/java/greencity/repository/NotificationPayloadRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationPayloadRepo.java
@@ -1,0 +1,9 @@
+package greencity.repository;
+
+import greencity.entity.NotificationPayload;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationPayloadRepo extends JpaRepository<NotificationPayload, Long> {
+}

--- a/dao/src/main/java/greencity/repository/NotificationRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationRepo.java
@@ -1,0 +1,9 @@
+package greencity.repository;
+
+import greencity.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotificationRepo extends JpaRepository<Notification, Long> {
+}

--- a/dao/src/main/java/greencity/repository/NotificationRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationRepo.java
@@ -1,9 +1,11 @@
 package greencity.repository;
 
 import greencity.entity.Notification;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepo extends JpaRepository<Notification, Long> {
+    List<Notification> findNotificationByUserId(Long id);
 }

--- a/dao/src/main/java/greencity/repository/NotificationRepo.java
+++ b/dao/src/main/java/greencity/repository/NotificationRepo.java
@@ -3,9 +3,12 @@ package greencity.repository;
 import greencity.entity.Notification;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NotificationRepo extends JpaRepository<Notification, Long> {
-    List<Notification> findNotificationByUserId(Long id);
+    @Query("SELECT n FROM Notification n WHERE n.userId = :userId ORDER BY n.timestamp ASC")
+    List<Notification> findNotificationByUserId(@Param("userId") Long id);
 }

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -176,5 +176,6 @@
     <include file="db/changelog/logs/ch-drop-places-table-Bokalo.xml"/>
     <include file="db/changelog/logs/ch-drop-news-subscribers-table-Bokalo.xml"/>
     <include file="db/changelog/logs/ch-drop-user-friends-table-Bokalo.xml"/>
+    <include file="db/changelog/logs/ch-add-table-notification-Lys.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -180,5 +180,6 @@
     <include file="db/changelog/logs/ch-add-table-notification-payload-Lys.xml"/>
     <include file="db/changelog/logs/ch-add-column-foreign-key-to-notification-table-Lys.xml"/>
     <include file="db/changelog/logs/ch-add-column-status-to-notification-table-Lys.xml"/>
+    <include file="db/changelog/logs/ch-add-column-timestampDeletion-to-notification-table-Lys.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -177,5 +177,7 @@
     <include file="db/changelog/logs/ch-drop-news-subscribers-table-Bokalo.xml"/>
     <include file="db/changelog/logs/ch-drop-user-friends-table-Bokalo.xml"/>
     <include file="db/changelog/logs/ch-add-table-notification-Lys.xml"/>
+    <include file="db/changelog/logs/ch-add-table-notification-payload-Lys.xml"/>
+    <include file="db/changelog/logs/ch-add-column-foreign-key-to-notification-table-Lys.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/dao/src/main/resources/db/changelog/db.changelog-master.xml
@@ -179,5 +179,6 @@
     <include file="db/changelog/logs/ch-add-table-notification-Lys.xml"/>
     <include file="db/changelog/logs/ch-add-table-notification-payload-Lys.xml"/>
     <include file="db/changelog/logs/ch-add-column-foreign-key-to-notification-table-Lys.xml"/>
+    <include file="db/changelog/logs/ch-add-column-status-to-notification-table-Lys.xml"/>
 </databaseChangeLog>
 

--- a/dao/src/main/resources/db/changelog/logs/ch-add-column-foreign-key-to-notification-table-Lys.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-column-foreign-key-to-notification-table-Lys.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-payload-id-to-notification" author="BohdanLys">
+        <addColumn tableName="notification">
+            <column name="payload_id" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <addForeignKeyConstraint
+                baseTableName="notification"
+                baseColumnNames="payload_id"
+                referencedTableName="notification_payload"
+                referencedColumnNames="id"
+                constraintName="fk_notification_payload"/>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-column-status-to-notification-table-Lys.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-column-status-to-notification-table-Lys.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-status-to-notification" author="BohdanLys">
+        <addColumn tableName="notification">
+            <column name="status" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-column-timestampDeletion-to-notification-table-Lys.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-column-timestampDeletion-to-notification-table-Lys.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="add-timestampDeletion-to-notification" author="BohdanLys">
+        <addColumn tableName="notification">
+            <column name="timestamp_deletion" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-table-notification-Lys.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-table-notification-Lys.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="create-notification-table" author="BohdanLys">
+        <createTable tableName="notification">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="event_type" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="user_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="source" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="timestamp" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/dao/src/main/resources/db/changelog/logs/ch-add-table-notification-payload-Lys.xml
+++ b/dao/src/main/resources/db/changelog/logs/ch-add-table-notification-payload-Lys.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet id="create-notification-payload-table" author="BohdanLys">
+        <createTable tableName="notification_payload">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="actor_id" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="actor_name" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="article_id" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="article_title" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="object_type" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/service-api/src/main/java/greencity/constant/ErrorMessage.java
+++ b/service-api/src/main/java/greencity/constant/ErrorMessage.java
@@ -133,6 +133,7 @@ public final class ErrorMessage {
     public static final String FILTER_NOT_FOUND_BY_ID = "Filter not found";
     public static final String USER_HAS_NO_FRIEND_WITH_ID = "User has no friend with this id: ";
     public static final String INVALID_DURATION = "The duration for such habit is lower than previously set";
+    public static final String INVALID_SOURCE = "Invalid source. Allowed values: ALL, GREENCITY, PICKUP";
 
     private ErrorMessage() {
     }

--- a/service-api/src/main/java/greencity/dto/notification/NotificationDtoRequest.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationDtoRequest.java
@@ -1,0 +1,18 @@
+package greencity.dto.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class NotificationDtoRequest {
+    private String actorName;
+    private String action;
+    private String object;
+    private String timestamp;
+    private String status;
+}

--- a/service-api/src/main/java/greencity/dto/notification/NotificationEvent.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationEvent.java
@@ -1,5 +1,6 @@
 package greencity.dto.notification;
 
+import greencity.enums.NotificationType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,7 +16,8 @@ public class NotificationEvent {
     /**
      * Type of event (COMMENT_CREATED, ARTICLE_LIKED, etc.).
      */
-    private String eventType;
+    //private String eventType;
+    private NotificationType eventType;
 
     /**
      * ID of the user who should receive the notification.

--- a/service-api/src/main/java/greencity/dto/notification/NotificationEvent.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationEvent.java
@@ -32,7 +32,7 @@ public class NotificationEvent {
     /**
      * Additional data specific to the event type.
      */
-    private Map<String, Object> payload;
+    private NotificationPayloadDto payload;
 
     /**
      * Timestamp when the event occurred.

--- a/service-api/src/main/java/greencity/dto/notification/NotificationEvent.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationEvent.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
-import java.util.Map;
 
 @Data
 @Builder
@@ -16,7 +15,6 @@ public class NotificationEvent {
     /**
      * Type of event (COMMENT_CREATED, ARTICLE_LIKED, etc.).
      */
-    //private String eventType;
     private NotificationType eventType;
 
     /**

--- a/service-api/src/main/java/greencity/dto/notification/NotificationEvent.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationEvent.java
@@ -1,0 +1,39 @@
+package greencity.dto.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationEvent {
+    /**
+     * Type of event (COMMENT_CREATED, ARTICLE_LIKED, etc.).
+     */
+    private String eventType;
+
+    /**
+     * ID of the user who should receive the notification.
+     */
+    private Long targetUserId;
+
+    /**
+     * Source of the notification.
+     */
+    private String source;
+
+    /**
+     * Additional data specific to the event type.
+     */
+    private Map<String, Object> payload;
+
+    /**
+     * Timestamp when the event occurred.
+     */
+    private LocalDateTime timestamp;
+}

--- a/service-api/src/main/java/greencity/dto/notification/NotificationPayloadDto.java
+++ b/service-api/src/main/java/greencity/dto/notification/NotificationPayloadDto.java
@@ -1,0 +1,22 @@
+package greencity.dto.notification;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationPayloadDto {
+    private Long actorId;
+
+    private String actorName;
+
+    private Long articleId;
+
+    private String articleTitle;
+
+    private String objectType;
+}

--- a/service-api/src/main/java/greencity/enums/NotificationType.java
+++ b/service-api/src/main/java/greencity/enums/NotificationType.java
@@ -1,0 +1,6 @@
+package greencity.enums;
+
+public enum NotificationType {
+    COMMENT_CREATED,
+    ARTICLE_LIKED
+}

--- a/service-api/src/main/java/greencity/exception/exceptions/NotificationNotFound.java
+++ b/service-api/src/main/java/greencity/exception/exceptions/NotificationNotFound.java
@@ -1,0 +1,7 @@
+package greencity.exception.exceptions;
+
+public class NotificationNotFound extends RuntimeException {
+    public NotificationNotFound(String message) {
+        super(message);
+    }
+}

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -1,0 +1,32 @@
+package greencity.service;
+
+import greencity.dto.notification.NotificationEvent;
+import java.util.List;
+
+/**
+ * Service interface for managing notifications.
+ */
+public interface NotificationService {
+    /**
+     * Retrieves all notifications as notification events.
+     *
+     * @return List of all notification events
+     */
+    List<NotificationEvent> findAllNotifications();
+
+    /**
+     * Retrieves a specific notification event by its ID.
+     *
+     * @param id ID of the notification to retrieve
+     * @return Notification event corresponding to the given ID
+     */
+    NotificationEvent findNotificationById(Long id);
+
+    /**
+     * Saves a notification event.
+     *
+     * @param notification Notification event to save
+     * @return Saved notification event
+     */
+    NotificationEvent saveNotification(NotificationEvent notification);
+}

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -19,9 +19,9 @@ public interface NotificationService {
      * Retrieves all notifications for specific user.
      *
      * @param id ID of the specific user
-     * @return  List of all notifications for specific user
+     * @return List of all notifications for specific user
      */
-    List<NotificationDtoRequest> findUserNotifications(Long id);
+    List<NotificationDtoRequest> findUserNotifications(Long id, String filter);
 
     /**
      * Retrieves a specific notification event by its ID.

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -38,4 +38,6 @@ public interface NotificationService {
      * @return Saved notification event
      */
     NotificationEvent saveNotification(NotificationEvent notification);
+
+    void deleteNotification(Long notificationId, Long userId);
 }

--- a/service-api/src/main/java/greencity/service/NotificationService.java
+++ b/service-api/src/main/java/greencity/service/NotificationService.java
@@ -1,5 +1,6 @@
 package greencity.service;
 
+import greencity.dto.notification.NotificationDtoRequest;
 import greencity.dto.notification.NotificationEvent;
 import java.util.List;
 
@@ -13,6 +14,14 @@ public interface NotificationService {
      * @return List of all notification events
      */
     List<NotificationEvent> findAllNotifications();
+
+    /**
+     * Retrieves all notifications for specific user.
+     *
+     * @param id ID of the specific user
+     * @return  List of all notifications for specific user
+     */
+    List<NotificationDtoRequest> findUserNotifications(Long id);
 
     /**
      * Retrieves a specific notification event by its ID.

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -55,6 +55,10 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <exclusions>

--- a/service/src/main/java/greencity/mapping/NotificationDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/NotificationDtoMapper.java
@@ -1,0 +1,21 @@
+package greencity.mapping;
+
+import greencity.dto.notification.NotificationEvent;
+import greencity.entity.Notification;
+import java.util.Collections;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationDtoMapper extends AbstractConverter<Notification, NotificationEvent> {
+    @Override
+    public NotificationEvent convert(Notification notification) {
+        return NotificationEvent.builder()
+            .eventType(notification.getEventType())
+            .targetUserId(notification.getUserId())
+            .source(notification.getSource())
+            .timestamp(notification.getTimestamp())
+            .payload(Collections.emptyMap()) // temporarily null
+            .build();
+    }
+}

--- a/service/src/main/java/greencity/mapping/NotificationDtoMapper.java
+++ b/service/src/main/java/greencity/mapping/NotificationDtoMapper.java
@@ -1,8 +1,8 @@
 package greencity.mapping;
 
 import greencity.dto.notification.NotificationEvent;
+import greencity.dto.notification.NotificationPayloadDto;
 import greencity.entity.Notification;
-import java.util.Collections;
 import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
 
@@ -15,7 +15,13 @@ public class NotificationDtoMapper extends AbstractConverter<Notification, Notif
             .targetUserId(notification.getUserId())
             .source(notification.getSource())
             .timestamp(notification.getTimestamp())
-            .payload(Collections.emptyMap()) // temporarily null
+            .payload(NotificationPayloadDto.builder()
+                .actorId(notification.getPayload().getActorId())
+                .actorName(notification.getPayload().getActorName())
+                .articleId(notification.getPayload().getArticleId())
+                .articleTitle(notification.getPayload().getArticleTitle())
+                .objectType(notification.getPayload().getObjectType())
+                .build())
             .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/NotificationDtoRequestMapper.java
+++ b/service/src/main/java/greencity/mapping/NotificationDtoRequestMapper.java
@@ -17,6 +17,7 @@ public class NotificationDtoRequestMapper extends AbstractConverter<Notification
             .object(notification.getPayload().getArticleTitle())
             .timestamp(notification.getTimestamp()
                 .truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+            .status(notification.getStatus().toString())
             .build();
     }
 }

--- a/service/src/main/java/greencity/mapping/NotificationDtoRequestMapper.java
+++ b/service/src/main/java/greencity/mapping/NotificationDtoRequestMapper.java
@@ -1,0 +1,22 @@
+package greencity.mapping;
+
+import greencity.dto.notification.NotificationDtoRequest;
+import greencity.entity.Notification;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationDtoRequestMapper extends AbstractConverter<Notification, NotificationDtoRequest> {
+    @Override
+    public NotificationDtoRequest convert(Notification notification) {
+        return NotificationDtoRequest.builder()
+            .actorName(notification.getPayload().getActorName())
+            .action(notification.getEventType().toString())
+            .object(notification.getPayload().getArticleTitle())
+            .timestamp(notification.getTimestamp()
+                .truncatedTo(ChronoUnit.SECONDS).format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+            .build();
+    }
+}

--- a/service/src/main/java/greencity/mapping/NotificationEventMapper.java
+++ b/service/src/main/java/greencity/mapping/NotificationEventMapper.java
@@ -1,0 +1,19 @@
+package greencity.mapping;
+
+import greencity.dto.notification.NotificationEvent;
+import greencity.entity.Notification;
+import org.modelmapper.AbstractConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationEventMapper extends AbstractConverter<NotificationEvent, Notification> {
+    @Override
+    public Notification convert(NotificationEvent notificationEvent) {
+        Notification notification = new Notification();
+        notification.setEventType(notificationEvent.getEventType());
+        notification.setSource(notificationEvent.getSource());
+        notification.setUserId(notificationEvent.getTargetUserId());
+        notification.setTimestamp(notificationEvent.getTimestamp());
+        return notification;
+    }
+}

--- a/service/src/main/java/greencity/mapping/NotificationEventMapper.java
+++ b/service/src/main/java/greencity/mapping/NotificationEventMapper.java
@@ -2,6 +2,7 @@ package greencity.mapping;
 
 import greencity.dto.notification.NotificationEvent;
 import greencity.entity.Notification;
+import greencity.entity.NotificationPayload;
 import org.modelmapper.AbstractConverter;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +15,13 @@ public class NotificationEventMapper extends AbstractConverter<NotificationEvent
         notification.setSource(notificationEvent.getSource());
         notification.setUserId(notificationEvent.getTargetUserId());
         notification.setTimestamp(notificationEvent.getTimestamp());
+        notification.setPayload(NotificationPayload.builder()
+            .actorId(notificationEvent.getPayload().getActorId())
+            .actorName(notificationEvent.getPayload().getActorName())
+            .articleId(notificationEvent.getPayload().getArticleId())
+            .articleTitle(notificationEvent.getPayload().getArticleTitle())
+            .objectType(notificationEvent.getPayload().getObjectType())
+            .build());
         return notification;
     }
 }

--- a/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsCommentServiceImpl.java
@@ -38,6 +38,7 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
     private final greencity.rating.RatingCalculation ratingCalculation;
     private final HttpServletRequest httpServletRequest;
     private final EcoNewsRepo ecoNewsRepo;
+    private final NotificationProducerService notificationProducerService;
 
     /**
      * Method to save {@link greencity.entity.EcoNewsComment}.
@@ -71,7 +72,20 @@ public class EcoNewsCommentServiceImpl implements EcoNewsCommentService {
         String accessToken = httpServletRequest.getHeader(AUTHORIZATION);
         CompletableFuture.runAsync(
             () -> ratingCalculation.ratingCalculation(RatingCalculationEnum.ADD_COMMENT, userVO, accessToken));
-        return modelMapper.map(ecoNewsCommentRepo.save(ecoNewsComment), AddEcoNewsCommentDtoResponse.class);
+
+        EcoNewsComment savedComment = ecoNewsCommentRepo.save(ecoNewsComment);
+
+        Long authorId = savedComment.getEcoNews().getAuthor().getId();
+        if (!authorId.equals(userVO.getId())) {
+            notificationProducerService.sendCommentNotification(
+                savedComment.getEcoNews().getId(),
+                savedComment.getEcoNews().getTitle(),
+                authorId,
+                userVO.getId(),
+                userVO.getName());
+        }
+
+        return modelMapper.map(savedComment, AddEcoNewsCommentDtoResponse.class);
     }
 
     /**

--- a/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
+++ b/service/src/main/java/greencity/service/EcoNewsServiceImpl.java
@@ -56,6 +56,7 @@ public class EcoNewsServiceImpl implements EcoNewsService {
     private final greencity.rating.RatingCalculation ratingCalculation;
     private final HttpServletRequest httpServletRequest;
     private final EcoNewsSearchRepo ecoNewsSearchRepo;
+    private final NotificationProducerService notificationProducerService;
     private final List<String> languageCode = List.of("en", "ua");
 
     /**
@@ -511,16 +512,35 @@ public class EcoNewsServiceImpl implements EcoNewsService {
      */
     @Override
     public void like(UserVO userVO, Long id) {
-        EcoNewsVO ecoNewsVO = findById(id);
-        if (ecoNewsVO.getUsersDislikedNews().stream().anyMatch(u -> u.getId().equals(userVO.getId()))) {
-            ecoNewsVO.getUsersDislikedNews().removeIf(u -> u.getId().equals(userVO.getId()));
+        EcoNews ecoNews = ecoNewsRepo.findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.ECO_NEWS_NOT_FOUND_BY_ID + id));
+        User liker = modelMapper.map(userVO, User.class);
+
+        if (ecoNews.getUsersDislikedNews().stream().anyMatch(user -> user.getId().equals(liker.getId()))) {
+            ecoNews.getUsersDislikedNews()
+                .removeIf(user -> user.getId().equals(liker.getId()));
         }
-        if (ecoNewsVO.getUsersLikedNews().stream().anyMatch(u -> u.getId().equals(userVO.getId()))) {
-            ecoNewsVO.getUsersLikedNews().removeIf(u -> u.getId().equals(userVO.getId()));
+
+        boolean alreadyLiked =
+            ecoNews.getUsersLikedNews().stream().anyMatch(user -> user.getId().equals(liker.getId()));
+
+        if (alreadyLiked) {
+            ecoNews.getUsersLikedNews()
+                .removeIf(user -> user.getId().equals(liker.getId()));
         } else {
-            ecoNewsVO.getUsersLikedNews().add(userVO);
+            ecoNews.getUsersLikedNews().add(liker);
+
+            User author = ecoNews.getAuthor();
+            if (!author.getId().equals(liker.getId())) {
+                notificationProducerService.sendLikeNotification(
+                    ecoNews.getId(),
+                    ecoNews.getTitle(),
+                    author.getId(),
+                    liker.getId(),
+                    liker.getName());
+            }
         }
-        ecoNewsRepo.save(modelMapper.map(ecoNewsVO, EcoNews.class));
+        ecoNewsRepo.save(ecoNews);
     }
 
     /**
@@ -531,16 +551,25 @@ public class EcoNewsServiceImpl implements EcoNewsService {
      */
     @Override
     public void dislike(UserVO userVO, Long id) {
-        EcoNewsVO ecoNewsVO = findById(id);
-        if (ecoNewsVO.getUsersLikedNews().stream().anyMatch(user -> user.getId().equals(userVO.getId()))) {
-            ecoNewsVO.getUsersLikedNews().removeIf(u -> u.getId().equals(userVO.getId()));
+        EcoNews ecoNews = ecoNewsRepo.findById(id)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.ECO_NEWS_NOT_FOUND_BY_ID + id));
+        User disliker = modelMapper.map(userVO, User.class);
+
+        if (ecoNews.getUsersLikedNews().stream().anyMatch(user -> user.getId().equals(disliker.getId()))) {
+            ecoNews.getUsersLikedNews()
+                .removeIf(user -> user.getId().equals(disliker.getId()));
         }
-        if (ecoNewsVO.getUsersDislikedNews().stream().anyMatch(user -> user.getId().equals(userVO.getId()))) {
-            ecoNewsVO.getUsersDislikedNews().removeIf(u -> u.getId().equals(userVO.getId()));
+
+        boolean alreadyDisliked =
+            ecoNews.getUsersDislikedNews().stream().anyMatch(user -> user.getId().equals(disliker.getId()));
+
+        if (alreadyDisliked) {
+            ecoNews.getUsersDislikedNews()
+                .removeIf(user -> user.getId().equals(disliker.getId()));
         } else {
-            ecoNewsVO.getUsersDislikedNews().add(userVO);
+            ecoNews.getUsersDislikedNews().add(disliker);
         }
-        ecoNewsRepo.save(modelMapper.map(ecoNewsVO, EcoNews.class));
+        ecoNewsRepo.save(ecoNews);
     }
 
     /**

--- a/service/src/main/java/greencity/service/NotificationProducerService.java
+++ b/service/src/main/java/greencity/service/NotificationProducerService.java
@@ -1,0 +1,81 @@
+package greencity.service;
+
+import greencity.dto.notification.NotificationEvent;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationProducerService {
+    private final KafkaTemplate<String, NotificationEvent> kafkaTemplate;
+    private static final String TOPIC = "notifications.greencity";
+    private static final String SOURCE = "GREENCITY";
+
+    /**
+     * Sends a notification about a comment on an article.
+     *
+     * @param articleId       ID of the article
+     * @param articleTitle    Title of the article
+     * @param authorId        ID of the article author (who will receive the
+     *                        notification)
+     * @param commentatorId   ID of the user who commented
+     * @param commentatorName Name of the user who commented
+     */
+    public void sendCommentNotification(Long articleId, String articleTitle,
+        Long authorId, Long commentatorId, String commentatorName) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("actorId", commentatorId);
+        payload.put("actorName", commentatorName);
+        payload.put("articleId", articleId);
+        payload.put("articleTitle", articleTitle);
+        payload.put("objectType", "ARTICLE");
+
+        NotificationEvent event = NotificationEvent.builder()
+            .eventType("COMMENT_CREATED")
+            .targetUserId(authorId)
+            .source(SOURCE)
+            .payload(payload)
+            .timestamp(LocalDateTime.now())
+            .build();
+
+        kafkaTemplate.send(TOPIC, event);
+        log.info("Comment notification sent to Kafka for user {}", authorId);
+    }
+
+    /**
+     * Sends a notification about a like on an article.
+     *
+     * @param articleId    ID of the article
+     * @param articleTitle Title of the article
+     * @param authorId     ID of the article author (who will receive the
+     *                     notification)
+     * @param likerId      ID of the user who liked
+     * @param likerName    Name of the user who liked
+     */
+    public void sendLikeNotification(Long articleId, String articleTitle,
+        Long authorId, Long likerId, String likerName) {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("actorId", likerId);
+        payload.put("actorName", likerName);
+        payload.put("articleId", articleId);
+        payload.put("articleTitle", articleTitle);
+        payload.put("objectType", "ARTICLE");
+
+        NotificationEvent event = NotificationEvent.builder()
+            .eventType("ARTICLE_LIKED")
+            .targetUserId(authorId)
+            .source(SOURCE)
+            .payload(payload)
+            .timestamp(LocalDateTime.now())
+            .build();
+
+        kafkaTemplate.send(TOPIC, event);
+        log.info("Like notification sent to Kafka for user {}", authorId);
+    }
+}

--- a/service/src/main/java/greencity/service/NotificationProducerService.java
+++ b/service/src/main/java/greencity/service/NotificationProducerService.java
@@ -29,7 +29,7 @@ public class NotificationProducerService {
      * @param commentatorName Name of the user who commented
      */
     public void sendCommentNotification(Long articleId, String articleTitle,
-                                        Long authorId, Long commentatorId, String commentatorName) {
+        Long authorId, Long commentatorId, String commentatorName) {
         NotificationPayloadDto notificationPayload = NotificationPayloadDto.builder()
             .actorId(commentatorId)
             .actorName(commentatorName)
@@ -62,7 +62,7 @@ public class NotificationProducerService {
      * @param likerName    Name of the user who liked
      */
     public void sendLikeNotification(Long articleId, String articleTitle,
-                                     Long authorId, Long likerId, String likerName) {
+        Long authorId, Long likerId, String likerName) {
         NotificationPayloadDto notificationPayload = NotificationPayloadDto.builder()
             .actorId(likerId)
             .actorName(likerName)

--- a/service/src/main/java/greencity/service/NotificationProducerService.java
+++ b/service/src/main/java/greencity/service/NotificationProducerService.java
@@ -1,6 +1,7 @@
 package greencity.service;
 
 import greencity.dto.notification.NotificationEvent;
+import greencity.enums.NotificationType;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
@@ -16,6 +17,7 @@ public class NotificationProducerService {
     private final KafkaTemplate<String, NotificationEvent> kafkaTemplate;
     private static final String TOPIC = "notifications.greencity";
     private static final String SOURCE = "GREENCITY";
+    private final NotificationService notificationService;
 
     /**
      * Sends a notification about a comment on an article.
@@ -37,7 +39,7 @@ public class NotificationProducerService {
         payload.put("objectType", "ARTICLE");
 
         NotificationEvent event = NotificationEvent.builder()
-            .eventType("COMMENT_CREATED")
+            .eventType(NotificationType.COMMENT_CREATED)
             .targetUserId(authorId)
             .source(SOURCE)
             .payload(payload)
@@ -45,6 +47,7 @@ public class NotificationProducerService {
             .build();
 
         kafkaTemplate.send(TOPIC, event);
+        notificationService.saveNotification(event);
         log.info("Comment notification sent to Kafka for user {}", authorId);
     }
 
@@ -68,7 +71,7 @@ public class NotificationProducerService {
         payload.put("objectType", "ARTICLE");
 
         NotificationEvent event = NotificationEvent.builder()
-            .eventType("ARTICLE_LIKED")
+            .eventType(NotificationType.ARTICLE_LIKED)
             .targetUserId(authorId)
             .source(SOURCE)
             .payload(payload)
@@ -76,6 +79,7 @@ public class NotificationProducerService {
             .build();
 
         kafkaTemplate.send(TOPIC, event);
+        notificationService.saveNotification(event);
         log.info("Like notification sent to Kafka for user {}", authorId);
     }
 }

--- a/service/src/main/java/greencity/service/NotificationProducerService.java
+++ b/service/src/main/java/greencity/service/NotificationProducerService.java
@@ -1,10 +1,9 @@
 package greencity.service;
 
 import greencity.dto.notification.NotificationEvent;
+import greencity.dto.notification.NotificationPayloadDto;
 import greencity.enums.NotificationType;
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -30,19 +29,20 @@ public class NotificationProducerService {
      * @param commentatorName Name of the user who commented
      */
     public void sendCommentNotification(Long articleId, String articleTitle,
-        Long authorId, Long commentatorId, String commentatorName) {
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("actorId", commentatorId);
-        payload.put("actorName", commentatorName);
-        payload.put("articleId", articleId);
-        payload.put("articleTitle", articleTitle);
-        payload.put("objectType", "ARTICLE");
+                                        Long authorId, Long commentatorId, String commentatorName) {
+        NotificationPayloadDto notificationPayload = NotificationPayloadDto.builder()
+            .actorId(commentatorId)
+            .actorName(commentatorName)
+            .articleId(articleId)
+            .articleTitle(articleTitle)
+            .objectType("ARTICLE")
+            .build();
 
         NotificationEvent event = NotificationEvent.builder()
             .eventType(NotificationType.COMMENT_CREATED)
             .targetUserId(authorId)
             .source(SOURCE)
-            .payload(payload)
+            .payload(notificationPayload)
             .timestamp(LocalDateTime.now())
             .build();
 
@@ -62,19 +62,20 @@ public class NotificationProducerService {
      * @param likerName    Name of the user who liked
      */
     public void sendLikeNotification(Long articleId, String articleTitle,
-        Long authorId, Long likerId, String likerName) {
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("actorId", likerId);
-        payload.put("actorName", likerName);
-        payload.put("articleId", articleId);
-        payload.put("articleTitle", articleTitle);
-        payload.put("objectType", "ARTICLE");
+                                     Long authorId, Long likerId, String likerName) {
+        NotificationPayloadDto notificationPayload = NotificationPayloadDto.builder()
+            .actorId(likerId)
+            .actorName(likerName)
+            .articleId(articleId)
+            .articleTitle(articleTitle)
+            .objectType("ARTICLE")
+            .build();
 
         NotificationEvent event = NotificationEvent.builder()
             .eventType(NotificationType.ARTICLE_LIKED)
             .targetUserId(authorId)
             .source(SOURCE)
-            .payload(payload)
+            .payload(notificationPayload)
             .timestamp(LocalDateTime.now())
             .build();
 

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -10,6 +10,7 @@ import greencity.mapping.NotificationEventMapper;
 import greencity.repository.NotificationRepo;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +21,8 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationDtoMapper notificationDtoMapper;
     private final NotificationEventMapper notificationEventMapper;
     private final NotificationDtoRequestMapper notificationDtoRequestMapper;
+
+    private static final Set<String> VALID_SOURCES = Set.of("ALL", "GREENCITY", "PICKUP");
 
     /**
      * Retrieves all notifications from the repository and maps them to notification
@@ -42,8 +45,16 @@ public class NotificationServiceImpl implements NotificationService {
      * @return List of all notification events
      */
     @Override
-    public List<NotificationDtoRequest> findUserNotifications(Long id) {
-        List<Notification> notifications = notificationRepo.findNotificationByUserId(id);
+    public List<NotificationDtoRequest> findUserNotifications(Long id, String filter) {
+        List<Notification> notifications;
+
+        if ("ALL".equalsIgnoreCase(filter)) {
+            notifications = notificationRepo.findNotificationByUserId(id);
+        } else {
+            notifications = notificationRepo.findNotificationByUserId(id).stream()
+                .filter(notification -> notification.getSource().equals(filter.toUpperCase()))
+                .toList();
+        }
 
         notifications.forEach(notification -> {
             notification.setStatus(NotificationStatus.READ);

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -1,0 +1,57 @@
+package greencity.service;
+
+import greencity.dto.notification.NotificationEvent;
+import greencity.entity.Notification;
+import greencity.mapping.NotificationDtoMapper;
+import greencity.mapping.NotificationEventMapper;
+import greencity.repository.NotificationRepo;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+    private final NotificationRepo notificationRepo;
+    private final NotificationDtoMapper notificationDtoMapper;
+    private final NotificationEventMapper notificationEventMapper;
+
+    /**
+     * Retrieves all notifications from the repository and maps them to notification events.
+     *
+     * @return List of all notification events
+     */
+    @Override
+    public List<NotificationEvent> findAllNotifications() {
+        return notificationRepo.findAll().stream()
+            .map(notificationDtoMapper::convert)
+            .toList();
+    }
+
+    /**
+     * Retrieves a specific notification by its ID and maps it to a notification event.
+     *
+     * @param id ID of the notification to retrieve
+     * @return Notification event corresponding to the given ID
+     * @throws EntityNotFoundException if the notification with the given ID does not exist
+     */
+    @Override
+    public NotificationEvent findNotificationById(Long id) {
+        Notification notification = notificationRepo.findById(id)
+            .orElseThrow(() -> new EntityNotFoundException("Notification not found"));
+
+        return notificationDtoMapper.convert(notification);
+    }
+
+    /**
+     * Saves a new notification event by converting it into a notification entity and persisting it.
+     *
+     * @param notification Notification event to save
+     * @return Saved notification event after persistence
+     */
+    @Override
+    public NotificationEvent saveNotification(NotificationEvent notification) {
+        return notificationDtoMapper.convert(notificationRepo.save(notificationEventMapper.convert(notification)));
+    }
+}

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -10,8 +10,8 @@ import greencity.mapping.NotificationDtoRequestMapper;
 import greencity.mapping.NotificationEventMapper;
 import greencity.repository.NotificationRepo;
 import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -24,8 +24,6 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationDtoMapper notificationDtoMapper;
     private final NotificationEventMapper notificationEventMapper;
     private final NotificationDtoRequestMapper notificationDtoRequestMapper;
-
-    private static final Set<String> VALID_SOURCES = Set.of("ALL", "GREENCITY", "PICKUP");
 
     /**
      * Retrieves all notifications from the repository and maps them to notification
@@ -41,33 +39,45 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     /**
-     * Retrieves all notifications from the repository for user and maps them to notification
-     * request.
+     * Retrieves all notifications for a user based on a filter, updates their status if unread,
+     * and schedules them for deletion or removes them if expired.
      *
-     * @param id ID of the user
-     * @return List of all notification events
+     * <p>If the filter is "ALL", all user notifications are returned. Otherwise, only notifications
+     * with a matching source are included.</p>
+     *
+     * <p>Unread notifications are marked as READ and scheduled for deletion after 5 minutes from the current time.
+     * If a notification is already READ and its deletion timestamp has passed, it is permanently removed.</p>
+     *
+     * @param id     ID of the user
+     * @param filter Filter for notification source (e.g., "EMAIL", "SYSTEM", or "ALL")
+     * @return List of filtered and mapped notification DTOs
      */
     @Override
     public List<NotificationDtoRequest> findUserNotifications(Long id, String filter) {
-        List<Notification> notifications;
+        List<NotificationDtoRequest> notifications;
 
         if ("ALL".equalsIgnoreCase(filter)) {
-            notifications = notificationRepo.findNotificationByUserId(id);
+            notifications = notificationRepo.findNotificationByUserId(id).stream()
+                .map(notificationDtoRequestMapper::convert)
+                .toList();
         } else {
             notifications = notificationRepo.findNotificationByUserId(id).stream()
                 .filter(notification -> notification.getSource().equals(filter.toUpperCase()))
+                .map(notificationDtoRequestMapper::convert)
                 .toList();
         }
-
-        notifications.forEach(notification -> {
-            notification.setStatus(NotificationStatus.READ);
-        });
-
-        notificationRepo.saveAll(notifications);
-
-        return notifications.stream()
-            .map(notificationDtoRequestMapper::convert)
-            .toList();
+        for (Notification notification : notificationRepo.findNotificationByUserId(id)) {
+            if (notification.getStatus() == NotificationStatus.UNREAD) {
+                notification.setStatus(NotificationStatus.READ);
+                notification.setTimestampDeletion(LocalDateTime.now().plusMinutes(5));
+                notificationRepo.save(notification);
+            } else {
+                if (LocalDateTime.now().isAfter(notification.getTimestampDeletion())) {
+                    notificationRepo.delete(notification);
+                }
+            }
+        }
+        return notifications;
     }
 
     /**
@@ -113,11 +123,9 @@ public class NotificationServiceImpl implements NotificationService {
                 break;
             }
         }
-
         if (!found) {
             throw new NotificationNotFound("Notification not found for user");
         }
-
         notificationRepo.deleteById(notificationId);
         log.info("Notification deleted successfully");
     }

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -4,6 +4,7 @@ import greencity.dto.notification.NotificationDtoRequest;
 import greencity.dto.notification.NotificationEvent;
 import greencity.entity.Notification;
 import greencity.enums.NotificationStatus;
+import greencity.exception.exceptions.NotificationNotFound;
 import greencity.mapping.NotificationDtoMapper;
 import greencity.mapping.NotificationDtoRequestMapper;
 import greencity.mapping.NotificationEventMapper;
@@ -12,8 +13,10 @@ import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @AllArgsConstructor
 public class NotificationServiceImpl implements NotificationService {
@@ -94,5 +97,28 @@ public class NotificationServiceImpl implements NotificationService {
     @Override
     public NotificationEvent saveNotification(NotificationEvent notification) {
         return notificationDtoMapper.convert(notificationRepo.save(notificationEventMapper.convert(notification)));
+    }
+
+    @Override
+    public void deleteNotification(Long notificationId, Long userId) {
+        log.info("Deleting notification with id: " + notificationId + " and userId: " + userId);
+        List<Notification> notifications = notificationRepo.findNotificationByUserId(userId);
+        log.info("Found " + notifications.size() + " notifications");
+        log.info(notifications.toString());
+
+        boolean found = false;
+        for (Notification notification : notifications) {
+            if (notification.getId().equals(notificationId)) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            throw new NotificationNotFound("Notification not found for user");
+        }
+
+        notificationRepo.deleteById(notificationId);
+        log.info("Notification deleted successfully");
     }
 }

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -1,8 +1,10 @@
 package greencity.service;
 
+import greencity.dto.notification.NotificationDtoRequest;
 import greencity.dto.notification.NotificationEvent;
 import greencity.entity.Notification;
 import greencity.mapping.NotificationDtoMapper;
+import greencity.mapping.NotificationDtoRequestMapper;
 import greencity.mapping.NotificationEventMapper;
 import greencity.repository.NotificationRepo;
 import jakarta.persistence.EntityNotFoundException;
@@ -16,9 +18,11 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationRepo notificationRepo;
     private final NotificationDtoMapper notificationDtoMapper;
     private final NotificationEventMapper notificationEventMapper;
+    private final NotificationDtoRequestMapper notificationDtoRequestMapper;
 
     /**
-     * Retrieves all notifications from the repository and maps them to notification events.
+     * Retrieves all notifications from the repository and maps them to notification
+     * events.
      *
      * @return List of all notification events
      */
@@ -30,11 +34,27 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     /**
-     * Retrieves a specific notification by its ID and maps it to a notification event.
+     * Retrieves all notifications from the repository for user and maps them to notification
+     * request.
+     *
+     * @param id ID of the user
+     * @return List of all notification events
+     */
+    @Override
+    public List<NotificationDtoRequest> findUserNotifications(Long id) {
+        return notificationRepo.findNotificationByUserId(id).stream()
+            .map(notificationDtoRequestMapper::convert)
+            .toList();
+    }
+
+    /**
+     * Retrieves a specific notification by its ID and maps it to a notification
+     * event.
      *
      * @param id ID of the notification to retrieve
      * @return Notification event corresponding to the given ID
-     * @throws EntityNotFoundException if the notification with the given ID does not exist
+     * @throws EntityNotFoundException if the notification with the given ID does
+     *                                 not exist
      */
     @Override
     public NotificationEvent findNotificationById(Long id) {
@@ -45,7 +65,8 @@ public class NotificationServiceImpl implements NotificationService {
     }
 
     /**
-     * Saves a new notification event by converting it into a notification entity and persisting it.
+     * Saves a new notification event by converting it into a notification entity
+     * and persisting it.
      *
      * @param notification Notification event to save
      * @return Saved notification event after persistence

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -3,6 +3,7 @@ package greencity.service;
 import greencity.dto.notification.NotificationDtoRequest;
 import greencity.dto.notification.NotificationEvent;
 import greencity.entity.Notification;
+import greencity.enums.NotificationStatus;
 import greencity.mapping.NotificationDtoMapper;
 import greencity.mapping.NotificationDtoRequestMapper;
 import greencity.mapping.NotificationEventMapper;
@@ -42,7 +43,15 @@ public class NotificationServiceImpl implements NotificationService {
      */
     @Override
     public List<NotificationDtoRequest> findUserNotifications(Long id) {
-        return notificationRepo.findNotificationByUserId(id).stream()
+        List<Notification> notifications = notificationRepo.findNotificationByUserId(id);
+
+        notifications.forEach(notification -> {
+            notification.setStatus(NotificationStatus.READ);
+        });
+
+        notificationRepo.saveAll(notifications);
+
+        return notifications.stream()
             .map(notificationDtoRequestMapper::convert)
             .toList();
     }

--- a/service/src/main/java/greencity/service/NotificationServiceImpl.java
+++ b/service/src/main/java/greencity/service/NotificationServiceImpl.java
@@ -111,10 +111,7 @@ public class NotificationServiceImpl implements NotificationService {
 
     @Override
     public void deleteNotification(Long notificationId, Long userId) {
-        log.info("Deleting notification with id: " + notificationId + " and userId: " + userId);
         List<Notification> notifications = notificationRepo.findNotificationByUserId(userId);
-        log.info("Found " + notifications.size() + " notifications");
-        log.info(notifications.toString());
 
         boolean found = false;
         for (Notification notification : notifications) {
@@ -127,6 +124,5 @@ public class NotificationServiceImpl implements NotificationService {
             throw new NotificationNotFound("Notification not found for user");
         }
         notificationRepo.deleteById(notificationId);
-        log.info("Notification deleted successfully");
     }
 }

--- a/service/src/test/java/greencity/mapping/NotificationDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/NotificationDtoMapperTest.java
@@ -1,12 +1,12 @@
 package greencity.mapping;
 
 import greencity.dto.notification.NotificationEvent;
+import greencity.dto.notification.NotificationPayloadDto;
 import greencity.entity.Notification;
+import greencity.entity.NotificationPayload;
 import greencity.enums.NotificationType;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -15,19 +15,33 @@ public class NotificationDtoMapperTest {
 
     @Test
     void convert_validNotification_returnsNotificationEvent() {
-        Notification notification = new Notification();
-        notification.setId(1L);
-        notification.setEventType(NotificationType.COMMENT_CREATED);
-        notification.setSource("source");
-        notification.setUserId(4L);
-        notification.setTimestamp(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+        Notification notification = Notification.builder()
+            .id(1L)
+            .eventType(NotificationType.COMMENT_CREATED)
+            .source("source")
+            .userId(4L)
+            .timestamp(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+            .payload(NotificationPayload.builder()
+                .actorId(3L)
+                .actorName("actor")
+                .articleId(1L)
+                .articleTitle("article")
+                .objectType("ARTICLE")
+                .build())
+            .build();
 
         NotificationEvent expected = NotificationEvent.builder()
             .eventType(NotificationType.COMMENT_CREATED)
             .source("source")
             .timestamp(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS))
             .targetUserId(4L)
-            .payload(Collections.emptyMap())
+            .payload(NotificationPayloadDto.builder()
+                .actorId(3L)
+                .actorName("actor")
+                .articleId(1L)
+                .articleTitle("article")
+                .objectType("ARTICLE")
+                .build())
             .build();
 
         NotificationEvent actual = notificationDtoMapper.convert(notification);

--- a/service/src/test/java/greencity/mapping/NotificationDtoMapperTest.java
+++ b/service/src/test/java/greencity/mapping/NotificationDtoMapperTest.java
@@ -1,0 +1,37 @@
+package greencity.mapping;
+
+import greencity.dto.notification.NotificationEvent;
+import greencity.entity.Notification;
+import greencity.enums.NotificationType;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class NotificationDtoMapperTest {
+    private final NotificationDtoMapper notificationDtoMapper = new NotificationDtoMapper();
+
+    @Test
+    void convert_validNotification_returnsNotificationEvent() {
+        Notification notification = new Notification();
+        notification.setId(1L);
+        notification.setEventType(NotificationType.COMMENT_CREATED);
+        notification.setSource("source");
+        notification.setUserId(4L);
+        notification.setTimestamp(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS));
+
+        NotificationEvent expected = NotificationEvent.builder()
+            .eventType(NotificationType.COMMENT_CREATED)
+            .source("source")
+            .timestamp(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+            .targetUserId(4L)
+            .payload(Collections.emptyMap())
+            .build();
+
+        NotificationEvent actual = notificationDtoMapper.convert(notification);
+
+        assertEquals(expected, actual);
+    }
+}

--- a/service/src/test/java/greencity/service/NotificationServiceImplTest.java
+++ b/service/src/test/java/greencity/service/NotificationServiceImplTest.java
@@ -1,0 +1,99 @@
+package greencity.service;
+
+import greencity.dto.notification.NotificationEvent;
+import greencity.entity.Notification;
+import greencity.enums.NotificationType;
+import greencity.mapping.NotificationDtoMapper;
+import greencity.mapping.NotificationEventMapper;
+import greencity.repository.NotificationRepo;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationServiceImplTest {
+    @Mock
+    private NotificationRepo notificationRepo;
+
+    @InjectMocks
+    private NotificationServiceImpl notificationService;
+
+    @Mock
+    private NotificationDtoMapper mapper;
+
+    @Mock
+    private NotificationEventMapper notificationEventMapper;
+
+    private NotificationEvent notificationEvent = NotificationEvent.builder()
+        .eventType(NotificationType.COMMENT_CREATED)
+        .source("source")
+        .timestamp(LocalDateTime.now())
+        .targetUserId(2L)
+        .build();
+
+    @Test
+    public void findNotificationById_existingNotification_success() {
+        Long id = 1L;
+        Notification notification = new Notification();
+        notification.setId(id);
+
+        when(notificationRepo.findById(id)).thenReturn(Optional.of(notification));
+        when(mapper.convert(notification)).thenReturn(notificationEvent);
+
+        assertEquals(notificationEvent, notificationService.findNotificationById(id));
+        verify(notificationRepo, times(1)).findById(id);
+    }
+
+    @Test
+    public void findNotificationById_notExistingNotification_throwsException() {
+        Long id = 2L;
+
+        when(notificationRepo.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> {
+            notificationService.findNotificationById(id);
+        });
+
+        verify(notificationRepo, times(1)).findById(id);
+    }
+
+    @Test
+    public void saveNotification_validNotificationEvent_success() {
+        NotificationEvent notificationToSave = NotificationEvent.builder()
+            .eventType(NotificationType.COMMENT_CREATED)
+            .source("source")
+            .timestamp(LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS))
+            .targetUserId(2L)
+            .build();
+
+        Notification mappedEntity = new Notification();
+        NotificationEvent mappedBackEvent = new NotificationEvent();
+        Notification savedEntity = new Notification();
+
+        when(notificationEventMapper.convert(notificationToSave)).thenReturn(mappedEntity);
+        when(notificationRepo.save(mappedEntity)).thenReturn(savedEntity);
+        when(mapper.convert(savedEntity)).thenReturn(mappedBackEvent);
+
+        // Act
+        NotificationEvent result = notificationService.saveNotification(notificationToSave);
+
+        System.out.println(result);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(mappedBackEvent, result);
+
+        verify(notificationEventMapper).convert(notificationToSave);
+        verify(notificationRepo).save(mappedEntity);
+        verify(mapper).convert(savedEntity);
+    }
+}


### PR DESCRIPTION
- Implemented `KafkaConfig` for producer configuration
- Created `NotificationEvent DTO` for standardized notification format
- Added `NotificationProducerService` for sending notifications to `Kafka`
- Integrated comment notifications in `EcoNewsCommentService` (task `#102`)
- Integrated like notifications in `EcoNewsService` (task `#103`)

This commit implements the producer part of the `Kafka` notification system, which sends events when users comment on or like articles. The implementation covers tasks `#102` (article comment notifications) and `#103` (article like notifications), working in conjunction with the consumer part in `GreenCityUser21`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced notification functionality for article comments and likes, notifying article authors when their articles receive comments or likes.
  - Added real-time notification delivery via Kafka messaging.
  - Added REST API endpoints for managing notifications, including creation, retrieval, filtering by user, and deletion.
- **Chores**
  - Added Kafka dependencies and configuration for message production.
  - Extended security settings to protect notification-related endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->